### PR TITLE
Fix macro syntax for fields with endianness + RW or RO

### DIFF
--- a/src/ll/register.rs
+++ b/src/ll/register.rs
@@ -568,7 +568,7 @@ macro_rules! _implement_register_field {
             use device_driver::bitvec::prelude::*;
             use device_driver::bitvec::view::AsBitsMut;
 
-            _store_with_endianness!(self.0.as_bits_mut::<$register_bit_order>()[$field_bit_range], value, $($field_bit_order:ident)?);
+            _store_with_endianness!(self.0.as_bits_mut::<$register_bit_order>()[$field_bit_range], value, $($field_bit_order)?);
 
             self
         }
@@ -581,7 +581,7 @@ macro_rules! _implement_register_field {
             use device_driver::bitvec::view::AsBitsMut;
 
             let raw_value: $field_type = value.into();
-            _store_with_endianness!(self.0.as_bits_mut::<$register_bit_order>()[$field_bit_range], raw_value, $($field_bit_order:ident)?);
+            _store_with_endianness!(self.0.as_bits_mut::<$register_bit_order>()[$field_bit_range], raw_value, $($field_bit_order)?);
 
             self
         }


### PR DESCRIPTION
I ran into a strange issue with `RW` or `RO` fields. Minimal repro:

```rust
implement_registers!(
    Max17302.registers<u16> = {
        test2(RW, 0x01B, 2) = { vcell: u16:LE = RW 0..16 },
    }
);
```

This gives an "unexpected token ..." error. Either removing `:LE` or changing both occurrences of `RW` to `RO` would fix the compilation error. Eventually tracked it down to the changes in this PR.