### PR TITLE
Added #[generate(Debug)] feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The best source to see how it works is the examples folder.
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![forbid(missing_docs)]
 
 pub use bit::Bit;
@@ -13,5 +13,7 @@ pub use bitvec;
 /// The module with tools for creating the low-level parts of the device driver
 #[macro_use]
 pub mod ll;
+
+pub mod utils;
 
 mod bit;

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -87,8 +87,8 @@ macro_rules! create_low_level_device {
             $($error_type($error_type))*
         }
 
-        impl From<ConversionError> for LowLevelError {
-            fn from(_: ConversionError) -> Self {
+        impl<T: core::fmt::UpperHex + Debug> From<ConversionError<T>> for LowLevelError {
+            fn from(_: ConversionError<T>) -> Self {
                 LowLevelError::ConversionError
             }
         }

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -87,7 +87,7 @@ macro_rules! create_low_level_device {
             $($error_type($error_type))*
         }
 
-        impl<T: core::fmt::UpperHex + Debug> From<ConversionError<T>> for LowLevelError {
+        impl<T: core::fmt::UpperHex + core::fmt::Debug> From<ConversionError<T>> for LowLevelError {
             fn from(_: ConversionError<T>) -> Self {
                 LowLevelError::ConversionError
             }

--- a/src/ll/register.rs
+++ b/src/ll/register.rs
@@ -224,7 +224,7 @@ macro_rules! _implement_register {
         }
 
         generate_if_debug_keyword!(
-            impl Debug for R {
+            impl core::fmt::Debug for R {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                     f.debug_struct(concat!(stringify!($register_name), "::R"))
                         .field("raw", &device_driver::utils::SliceHexFormatter::new(&self.0))
@@ -234,7 +234,7 @@ macro_rules! _implement_register {
                         .finish()
                 }
             },
-            impl Debug for R {
+            impl core::fmt::Debug for R {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                     f.debug_struct(concat!(stringify!($register_name), "::R"))
                         .field("raw", &device_driver::utils::SliceHexFormatter::new(&self.0))
@@ -295,7 +295,7 @@ macro_rules! _implement_register {
         }
 
         generate_if_debug_keyword!(
-            impl Debug for R {
+            impl core::fmt::Debug for R {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                     f.debug_struct(concat!(stringify!($register_name), "::R"))
                         .field("raw", &device_driver::utils::SliceHexFormatter::new(&self.0))
@@ -305,7 +305,7 @@ macro_rules! _implement_register {
                         .finish()
                 }
             },
-            impl Debug for R {
+            impl core::fmt::Debug for R {
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
                     f.debug_struct(concat!(stringify!($register_name), "::R"))
                         .field("raw", &device_driver::utils::SliceHexFormatter::new(&self.0))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,43 @@
+//! Module containing utilities. As a user of this crate, you shouldn't have to use this directly and
+//! because it is used in the macros, these need to be public.
+//!
+
+use core::fmt::{Debug, Formatter, Result};
+
+/// A wrapper around a slice that formats everything to upper hex
+pub struct SliceHexFormatter<'a> {
+    slice: &'a [u8],
+}
+
+impl<'a> SliceHexFormatter<'a> {
+    /// Wrap around the value
+    pub fn new(slice: &'a [u8]) -> Self {
+        Self { slice }
+    }
+}
+
+impl<'a> Debug for SliceHexFormatter<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "0x")?;
+        for elem in self.slice {
+            write!(f, "{:02X}", elem)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slice_hex_formatter() {
+        assert_eq!(
+            format!(
+                "{:?}",
+                SliceHexFormatter::new(&[0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01])
+            ),
+            "DEADBEEF0001".to_string()
+        );
+    }
+}


### PR DESCRIPTION
Closes #8 

You can now do this:

```rust
implement_registers!(
    MyDevice.registers<u8> = {
        // (comments must go first)
        #[generate(Debug)]              // <- new!
        id(RO, 0, 3) = MSB {
            manufacturer: u16:LE as Manufacturer = RW 0..16,
            version: u8:NE = RO 16..20,
            edition: u8:BE = RO 20..24,
        },
    }
);
```

Then we can:

```rust
let id = device.registers().id().read()?;
println!("{:?}", id);
```
```
id::R { raw: 0x010065, manufacturer: Ok(CarmineCrystal), version: 6, edition: 5 }
```

The generate attribute is optional. If you don't add it to the register, the output is now better too:
```
id::R { raw: 0x010065 }
```

When opting in, all field types must impl Debug.

This attribute syntax can be used later for other things as well.