### PR TITLE
Add doc to LowLevelError variants

### DIFF
--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -83,8 +83,12 @@ macro_rules! create_low_level_device {
         /// Error type containing all low level errors
         #[derive(Debug)]
         pub enum LowLevelError {
+            /// Error variant for type conversion errors
             ConversionError,
-            $($error_type($error_type))*
+            $(
+            #[doc = concat!("Error variant containing [", stringify!($error_type), "]")]
+            $error_type($error_type)
+            )*
         }
 
         impl<T: core::fmt::UpperHex + core::fmt::Debug> From<ConversionError<T>> for LowLevelError {


### PR DESCRIPTION
This makes it possible to activate the `missing_docs` lint in drivers using this crate.