### PR TITLE
Allow cfg attributes on Register, Command, Buffer and Field

### DIFF
--- a/device-driver/examples/test-macro-driver.rs
+++ b/device-driver/examples/test-macro-driver.rs
@@ -192,6 +192,27 @@ pub mod registers {
                 const SIZE_BITS: usize = 16;
                 const RESET_VALUE: u16 = 0x1234;
 
+                #[cfg(windows)]
+                value: u16 = 0..16,
+                #[cfg(not(windows))]
+                value: u16 = 0..16,
+            },
+            #[cfg(windows)]
+            register Bar {
+                type RWType = RW;
+                const ADDRESS: u8 = 0;
+                const SIZE_BITS: usize = 16;
+                const RESET_VALUE: u16 = 0x1234;
+
+                value: u16 = 0..16,
+            },
+            #[cfg(not(windows))]
+            register Bar {
+                type RWType = RW;
+                const ADDRESS: u8 = 0;
+                const SIZE_BITS: usize = 16;
+                const RESET_VALUE: u16 = 0x5678;
+
                 value: u16 = 0..16,
             },
             command Sleep = 0,
@@ -235,6 +256,12 @@ fn main() {
 
     test_device.foo().write(|w| w).unwrap();
     assert_eq!(test_device.foo().read().unwrap().value(), 0x1234);
+
+    test_device.bar().clear().unwrap();
+    #[cfg(windows)]
+    assert_eq!(test_device.bar().read().unwrap().value(), 0x1234);
+    #[cfg(not(windows))]
+    assert_eq!(test_device.bar().read().unwrap().value(), 0x5678);
 
     test_device.sleep().dispatch().unwrap();
     assert_eq!(test_device.last_command, 0);

--- a/generation/src/generation.rs
+++ b/generation/src/generation.rs
@@ -364,11 +364,11 @@ impl Register {
                     pub fn into_register(self) -> #pascal_case_name {
                         self.into()
                     }
-                    
+
                     #field_functions_write
                     #field_functions_read_explicit
                 }
-    
+
                 #[doc = #r_doc_string]
                 #[derive(Copy, Clone, Eq, PartialEq)]
                 pub struct R {

--- a/generation/src/generation.rs
+++ b/generation/src/generation.rs
@@ -71,7 +71,7 @@ impl Command {
             quote!()
         };
 
-        let attributes = &self.attributes;
+        let attributes = &self.cfg_attributes;
         let id = proc_macro2::Literal::u32_unsuffixed(self.id);
 
         syn::parse_quote! {
@@ -95,7 +95,7 @@ impl Buffer {
             quote!()
         };
 
-        let attributes = &self.attributes;
+        let attributes = &self.cfg_attributes;
         let id = proc_macro2::Literal::u32_unsuffixed(self.id);
         let rw_type = self.rw_type.into_type();
 
@@ -439,7 +439,7 @@ impl Field {
             register_type,
             start,
             end,
-            attributes,
+            cfg_attributes,
         } = self;
 
         let (conversion_type, strict_conversion) = match (conversion, strict_conversion) {
@@ -477,7 +477,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> Result<#conversion_type, <#conversion_type as TryFrom<#register_type>>::Error> {
                         device_driver::read_field_bool::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -487,7 +487,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #conversion_type {
                         device_driver::read_field_bool_strict::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -496,7 +496,7 @@ impl Field {
             (BaseType::Bool, Some(end), None, _) if end == self.start + 1 => {
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #register_type {
                         device_driver::read_field_bool_no_convert::<Self, _, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -506,7 +506,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> Result<#conversion_type, <#conversion_type as TryFrom<#register_type>>::Error> {
                         device_driver::read_field_bool::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -516,7 +516,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #conversion_type {
                         device_driver::read_field_bool_strict::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -525,7 +525,7 @@ impl Field {
             (BaseType::Bool, None, None, _) => {
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #register_type {
                         device_driver::read_field_bool_no_convert::<Self, _, #start, { Self::SIZE_BYTES }>(self)
                     }
@@ -540,7 +540,7 @@ impl Field {
 
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> Result<#conversion_type, <#conversion_type as TryFrom<#register_type>>::Error> {
                         device_driver::read_field::<Self, _, #conversion_type, #register_type, #start, #end, { Self::SIZE_BYTES }>(self)
                     }
@@ -552,7 +552,7 @@ impl Field {
 
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #conversion_type {
                         device_driver::read_field_strict::<Self, _, #conversion_type, #register_type, #start, #end, { Self::SIZE_BYTES }>(self)
                     }
@@ -563,7 +563,7 @@ impl Field {
 
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&self) -> #register_type {
                         device_driver::read_field_no_convert::<Self, _, #register_type, #start, #end, { Self::SIZE_BYTES }>(self)
                     }
@@ -584,7 +584,7 @@ impl Field {
             register_type,
             start,
             end,
-            attributes,
+            cfg_attributes,
         } = self;
 
         let conversion_type = match (conversion, strict_conversion) {
@@ -615,7 +615,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #conversion_type) -> &mut Self {
                         device_driver::write_field_bool::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self, data)
                     }
@@ -624,7 +624,7 @@ impl Field {
             (BaseType::Bool, Some(end), None) if end == self.start + 1 => {
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #register_type) -> &mut Self {
                         device_driver::write_field_bool_no_convert::<Self, _, #start, { Self::SIZE_BYTES }>(self, data)
                     }
@@ -634,7 +634,7 @@ impl Field {
                 let conversion_type = conversion_type.into_type(name);
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #conversion_type) -> &mut Self {
                         device_driver::write_field_bool::<Self, _, #conversion_type, #start, { Self::SIZE_BYTES }>(self, data)
                     }
@@ -643,7 +643,7 @@ impl Field {
             (BaseType::Bool, None, None) => {
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #register_type) -> &mut Self {
                         device_driver::write_field_bool_no_convert::<Self, _, #start, { Self::SIZE_BYTES }>(self, data)
                     }
@@ -658,7 +658,7 @@ impl Field {
 
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #conversion_type) -> &mut Self {
                         device_driver::write_field::<Self, _, #conversion_type, #register_type, #start, #end, { Self::SIZE_BYTES }>(self, data)
                     }
@@ -669,7 +669,7 @@ impl Field {
 
                 quote! {
                     #doc_attribute
-                    #(#attributes)*
+                    #(#cfg_attributes)*
                     pub fn #snake_case_name(&mut self, data: #register_type) -> &mut Self {
                         device_driver::write_field_no_convert::<Self, _, #register_type, #start, #end, { Self::SIZE_BYTES }>(self, data)
                     }

--- a/generation/src/lib.rs
+++ b/generation/src/lib.rs
@@ -35,6 +35,8 @@ pub struct Register {
     pub description: Option<String>,
     pub reset_value: Option<ResetValue>,
     pub fields: FieldCollection,
+    #[serde(skip)]
+    pub cfg_attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Register {
@@ -63,6 +65,8 @@ pub struct Field {
     pub strict_conversion: Option<TypePathOrEnum>,
     pub start: u32,
     pub end: Option<u32>,
+    #[serde(skip)]
+    pub attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Field {
@@ -86,6 +90,8 @@ pub struct Command {
     pub name: String,
     pub id: u32,
     pub description: Option<String>,
+    #[serde(skip)]
+    pub attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Command {
@@ -110,6 +116,8 @@ pub struct Buffer {
     pub id: u32,
     pub description: Option<String>,
     pub rw_type: RWType,
+    #[serde(skip)]
+    pub attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Buffer {

--- a/generation/src/lib.rs
+++ b/generation/src/lib.rs
@@ -66,7 +66,7 @@ pub struct Field {
     pub start: u32,
     pub end: Option<u32>,
     #[serde(skip)]
-    pub attributes: Vec<syn::Attribute>,
+    pub cfg_attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Field {
@@ -91,7 +91,7 @@ pub struct Command {
     pub id: u32,
     pub description: Option<String>,
     #[serde(skip)]
-    pub attributes: Vec<syn::Attribute>,
+    pub cfg_attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Command {
@@ -117,7 +117,7 @@ pub struct Buffer {
     pub description: Option<String>,
     pub rw_type: RWType,
     #[serde(skip)]
-    pub attributes: Vec<syn::Attribute>,
+    pub cfg_attributes: Vec<syn::Attribute>,
 }
 
 impl PartialOrd for Buffer {


### PR DESCRIPTION
A device I'm implementing a driver for has certain registers and fields which are available and/or change based on the variant of the part. This is being implemented with feature flags on the driver crate. Currently there's no way to conditionally include fields or registers based on feature flags. This change adds support for arbitrary attributes to `Command`, `Buffer` and `Field` and for `cfg` attributes on `Register` when using the procedural macro syntax.