### PR TITLE
Change bitvec source to fix xtensa support

### DIFF
--- a/device-driver/Cargo.toml
+++ b/device-driver/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 device-driver-macros = { version = "=1.0.2", path = "../macros", default-features = false, optional = true }
 
-bitvec = { version = "1.0.1", default-features = false }
+bitvec = { git = "https://github.com/alexanderkjall/bitvec", branch = "upgrade-radium-to-1", default-features = false }
 embedded-io = "0.6.1"
 embedded-io-async = "0.6.1"
 defmt = { version = "0.3", optional = true }

--- a/generation/Cargo.toml
+++ b/generation/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.14.0"
 proc-macro2 = "1.0.70"
 quote = "1.0.33"
 syn = { version = "2.0", features = ["extra-traits"] }
-bitvec = "1.0.1"
+bitvec = { git = "https://github.com/alexanderkjall/bitvec", branch = "upgrade-radium-to-1" }
 dd-manifest-tree = { version = "1.0.0", path = "../dd-manifest-tree", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
`bitvec` is using an outdated version of `radium` which did support xtensa targets.

The updated version has a branch where the dependency is updated.

I've tested this on an esp32-s3.

This fixes #59