### PR TITLE
Bye bitvec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Unreleased
 
+- *(Technically breaking)*: removed the `pub use bitvec;` in the root of the crate.
+  - It was an oversight to have that still there without `#[doc(hidden)]`
+  - There was no reason for anyone to use it
+  - Nothing publicly on github is using it
+  - So we're doing 'scream testing'. If this impacts you, message me! I'll yank the release immediately
+- Replaced bitvec with custom logic
+  - Bitvec doesn't compile for Xtensa arch due to it being unmaintained
+  - Custom logic is smaller and saves program size
+
 ### 1.0.2 (03-01-25)
 
 - Add more docs to generated code so it passes the `missing_docs` lint

--- a/device-driver/Cargo.toml
+++ b/device-driver/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 [dependencies]
 device-driver-macros = { version = "=1.0.2", path = "../macros", default-features = false, optional = true }
 
-bitvec = { version = "1.0.1", default-features = false }
 embedded-io = "0.6.1"
 embedded-io-async = "0.6.1"
 defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
+bitvec = { version = "1.0.1", default-features = false }
 rand = "0.9"
 
 [features]

--- a/device-driver/Cargo.toml
+++ b/device-driver/Cargo.toml
@@ -19,6 +19,9 @@ embedded-io = "0.6.1"
 embedded-io-async = "0.6.1"
 defmt = { version = "0.3", optional = true }
 
+[dev-dependencies]
+rand = "0.9"
+
 [features]
 default = ["dsl", "json", "yaml", "toml"]
 dsl = ["_macros", "device-driver-macros/dsl"]

--- a/device-driver/src/buffer.rs
+++ b/device-driver/src/buffer.rs
@@ -146,7 +146,7 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Access> BufferOperation<'i, Interface, AddressType, Access>
+impl<Interface, AddressType: Copy, Access> BufferOperation<'_, Interface, AddressType, Access>
 where
     Interface: AsyncBufferInterface<AddressType = AddressType>,
     Access: WriteCapability,
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Access> BufferOperation<'i, Interface, AddressType, Access>
+impl<Interface, AddressType: Copy, Access> BufferOperation<'_, Interface, AddressType, Access>
 where
     Interface: AsyncBufferInterface<AddressType = AddressType>,
     Access: ReadCapability,
@@ -257,8 +257,8 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Access> embedded_io_async::Write
-    for BufferOperation<'i, Interface, AddressType, Access>
+impl<Interface, AddressType: Copy, Access> embedded_io_async::Write
+    for BufferOperation<'_, Interface, AddressType, Access>
 where
     Interface: AsyncBufferInterface<AddressType = AddressType>,
     Interface::Error: embedded_io::Error,
@@ -273,8 +273,8 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Access> embedded_io_async::Read
-    for BufferOperation<'i, Interface, AddressType, Access>
+impl<Interface, AddressType: Copy, Access> embedded_io_async::Read
+    for BufferOperation<'_, Interface, AddressType, Access>
 where
     Interface: AsyncBufferInterface<AddressType = AddressType>,
     Interface::Error: embedded_io::Error,

--- a/device-driver/src/command.rs
+++ b/device-driver/src/command.rs
@@ -98,7 +98,7 @@ where
         self.interface.dispatch_command(
             self.address,
             InFieldSet::SIZE_BITS,
-            InFieldSet::BUFFER::from(in_fields).as_ref(),
+            in_fields.get_inner_buffer(),
             0,
             &mut [],
         )
@@ -113,17 +113,17 @@ where
 {
     /// Dispatch the command to the device
     pub fn dispatch(self) -> Result<OutFieldSet, Interface::Error> {
-        let mut buffer = OutFieldSet::BUFFER::from(OutFieldSet::new_with_zero());
+        let mut out_fields = OutFieldSet::new_with_zero();
 
         self.interface.dispatch_command(
             self.address,
             0,
             &[],
             OutFieldSet::SIZE_BITS,
-            buffer.as_mut(),
+            out_fields.get_inner_buffer_mut(),
         )?;
 
-        Ok(buffer.into())
+        Ok(out_fields.into())
     }
 }
 
@@ -141,17 +141,17 @@ where
         let mut in_fields = InFieldSet::new_with_zero();
         f(&mut in_fields);
 
-        let mut buffer = OutFieldSet::BUFFER::from(OutFieldSet::new_with_zero());
+        let mut out_fields = OutFieldSet::new_with_zero();
 
         self.interface.dispatch_command(
             self.address,
             InFieldSet::SIZE_BITS,
-            InFieldSet::BUFFER::from(in_fields).as_ref(),
+            in_fields.get_inner_buffer(),
             OutFieldSet::SIZE_BITS,
-            buffer.as_mut(),
+            out_fields.get_inner_buffer_mut(),
         )?;
 
-        Ok(buffer.into())
+        Ok(out_fields.into())
     }
 }
 
@@ -186,7 +186,7 @@ where
             .dispatch_command(
                 self.address,
                 InFieldSet::SIZE_BITS,
-                InFieldSet::BUFFER::from(in_fields).as_ref(),
+                in_fields.get_inner_buffer(),
                 0,
                 &mut [],
             )
@@ -202,7 +202,7 @@ where
 {
     /// Dispatch the command to the device
     pub async fn dispatch_async(self) -> Result<OutFieldSet, Interface::Error> {
-        let mut buffer = OutFieldSet::BUFFER::from(OutFieldSet::new_with_zero());
+        let mut out_fields = OutFieldSet::new_with_zero();
 
         self.interface
             .dispatch_command(
@@ -210,11 +210,11 @@ where
                 0,
                 &[],
                 OutFieldSet::SIZE_BITS,
-                buffer.as_mut(),
+                out_fields.get_inner_buffer_mut(),
             )
             .await?;
 
-        Ok(buffer.into())
+        Ok(out_fields.into())
     }
 }
 
@@ -232,18 +232,18 @@ where
         let mut in_fields = InFieldSet::new_with_zero();
         f(&mut in_fields);
 
-        let mut buffer = OutFieldSet::BUFFER::from(OutFieldSet::new_with_zero());
+        let mut out_fields = OutFieldSet::new_with_zero();
 
         self.interface
             .dispatch_command(
                 self.address,
                 InFieldSet::SIZE_BITS,
-                InFieldSet::BUFFER::from(in_fields).as_ref(),
+                in_fields.get_inner_buffer(),
                 OutFieldSet::SIZE_BITS,
-                buffer.as_mut(),
+                out_fields.get_inner_buffer_mut(),
             )
             .await?;
 
-        Ok(buffer.into())
+        Ok(out_fields.into())
     }
 }

--- a/device-driver/src/command.rs
+++ b/device-driver/src/command.rs
@@ -123,7 +123,7 @@ where
             out_fields.get_inner_buffer_mut(),
         )?;
 
-        Ok(out_fields.into())
+        Ok(out_fields)
     }
 }
 
@@ -151,12 +151,12 @@ where
             out_fields.get_inner_buffer_mut(),
         )?;
 
-        Ok(out_fields.into())
+        Ok(out_fields)
     }
 }
 
 /// Simple command async
-impl<'i, Interface, AddressType: Copy> CommandOperation<'i, Interface, AddressType, (), ()>
+impl<Interface, AddressType: Copy> CommandOperation<'_, Interface, AddressType, (), ()>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
@@ -169,8 +169,8 @@ where
 }
 
 /// Only input async
-impl<'i, Interface, AddressType: Copy, InFieldSet: FieldSet>
-    CommandOperation<'i, Interface, AddressType, InFieldSet, ()>
+impl<Interface, AddressType: Copy, InFieldSet: FieldSet>
+    CommandOperation<'_, Interface, AddressType, InFieldSet, ()>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
@@ -195,8 +195,8 @@ where
 }
 
 /// Only output async
-impl<'i, Interface, AddressType: Copy, OutFieldSet: FieldSet>
-    CommandOperation<'i, Interface, AddressType, (), OutFieldSet>
+impl<Interface, AddressType: Copy, OutFieldSet: FieldSet>
+    CommandOperation<'_, Interface, AddressType, (), OutFieldSet>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
@@ -214,13 +214,13 @@ where
             )
             .await?;
 
-        Ok(out_fields.into())
+        Ok(out_fields)
     }
 }
 
 /// Input and output async
-impl<'i, Interface, AddressType: Copy, InFieldSet: FieldSet, OutFieldSet: FieldSet>
-    CommandOperation<'i, Interface, AddressType, InFieldSet, OutFieldSet>
+impl<Interface, AddressType: Copy, InFieldSet: FieldSet, OutFieldSet: FieldSet>
+    CommandOperation<'_, Interface, AddressType, InFieldSet, OutFieldSet>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
@@ -244,6 +244,6 @@ where
             )
             .await?;
 
-        Ok(out_fields.into())
+        Ok(out_fields)
     }
 }

--- a/device-driver/src/lib.rs
+++ b/device-driver/src/lib.rs
@@ -5,7 +5,6 @@
 
 use core::fmt::{Debug, Display};
 
-pub use bitvec;
 pub use embedded_io;
 pub use embedded_io_async;
 
@@ -24,16 +23,14 @@ pub use device_driver_macros::*;
 
 #[doc(hidden)]
 pub trait FieldSet {
-    /// The inner buffer type
-    type BUFFER: From<Self> + Into<Self> + AsMut<[u8]> + AsRef<[u8]>
-    where
-        Self: Sized;
-
     /// The size of the field set in number of bits
     const SIZE_BITS: u32;
 
     /// Create a new instance, loaded all 0's
     fn new_with_zero() -> Self;
+
+    fn get_inner_buffer(&self) -> &[u8];
+    fn get_inner_buffer_mut(&mut self) -> &mut [u8];
 }
 
 /// The error returned by the generated [TryFrom]s.

--- a/device-driver/src/lib.rs
+++ b/device-driver/src/lib.rs
@@ -16,6 +16,9 @@ pub use command::*;
 mod buffer;
 pub use buffer::*;
 
+#[doc(hidden)]
+pub mod ops;
+
 #[cfg(feature = "_macros")]
 pub use device_driver_macros::*;
 

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -277,12 +277,14 @@ pub trait ByteOrder {
 }
 
 impl ByteOrder for LE {
+    #[inline]
     fn get_byte_index(_data_len: usize, bit_index: usize) -> usize {
         bit_index / 8
     }
 }
 
 impl ByteOrder for BE {
+    #[inline]
     fn get_byte_index(data_len: usize, bit_index: usize) -> usize {
         data_len - (bit_index / 8) - 1
     }

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -179,7 +179,7 @@ mod tests {
     fn same_as_bitvec() {
         use bitvec::{field::BitField, view::BitView};
 
-        for _ in 0..1_000_000 {
+        for _ in 0..10_000 {
             let mut data = vec![0u8; rand::random_range(1..=16)];
             rand::fill(&mut data[..]);
             let mut reversed_data = data.clone();

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -32,7 +32,7 @@ where
             } else {
                 // Go bit by bit
                 // Move the target bit all the way to the right so we know where it is
-                let bit = (byte >> i % 8) & 1;
+                let bit = (byte >> (i % 8)) & 1;
                 // Shift the bit the proper amount to the left. The bit at `start` should be at index 0
                 output |= T::detruncate(bit) << (i - start);
                 i += 1;
@@ -77,10 +77,10 @@ where
                 let bit = (value >> (i - start)).truncate() & 1;
 
                 // Clear the bit
-                *byte &= !(1 << i % 8);
+                *byte &= !(1 << (i % 8));
                 // If the bit is set, set the bit in the byte
                 // Not if statement here since this is faster and smaller
-                *byte |= bit << i % 8;
+                *byte |= bit << (i % 8);
 
                 i += 1;
             }
@@ -130,7 +130,7 @@ where
                 // Move the target bit all the way to the right so we know where it is
                 let bit = (byte >> (7 - i % 8)) & 1;
                 // Shift the bit the proper amount to the left. The bit at `start` should be at index 0
-                output |= T::detruncate(bit) << (j as usize - start);
+                output |= T::detruncate(bit) << (j - start);
                 i += 1;
             }
         }
@@ -238,9 +238,9 @@ fn pivot_msb0(start: usize, end: usize, i: usize) -> usize {
     // The pivot is off by a half if we have an even number of bits.
     // But we've done a `* 2` previously now, so we can correct the half-error with a whole number.
     if diff > 0 {
-        j -= 1 * num_bits_even as isize;
+        j -= num_bits_even as isize;
     } else {
-        j += 1 * num_bits_even as isize;
+        j += num_bits_even as isize;
     }
 
     j as usize
@@ -368,7 +368,7 @@ mod tests {
 
     struct Bytes<'a>(&'a [u8]);
 
-    impl<'a> std::fmt::Binary for Bytes<'a> {
+    impl std::fmt::Binary for Bytes<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "[")?;
             for byte in self.0 {

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -1,11 +1,8 @@
-use core::ops::{BitAnd, BitOrAssign, Shl, Shr};
+use core::ops::{BitOrAssign, Shl};
 
 pub unsafe fn load_lsb0<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
 where
-    T: Default
-        + From<u8>
-        + Shl<usize, Output = T>
-        + BitOrAssign,
+    T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign,
 {
     let mut output = T::default();
 
@@ -28,17 +25,50 @@ where
 
 pub unsafe fn load_msb0<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
 where
-    T: Default
-        + From<u8>
-        + Shr<usize, Output = T>
-        + BitAnd<T, Output = T>
-        + Shl<usize, Output = T>
-        + BitOrAssign
-        + SwapBytes,
+    T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign,
 {
-    let new_start = data.len() * 8 - end;
-    let new_end = data.len() * 8 - start;
-    load_lsb0::<T, ByteO::Opposite>(data, new_start, new_end)//.swap_bytes()
+    let mut output = T::default();
+
+    let mut i = start;
+    while i < end {
+        let byte = ByteO::get_byte_from_index(data, i);
+
+        if (i % 8 == 0) & (i + 8 <= end) {
+            output |= T::from(byte) << (i - start);
+            i += 8;
+        } else {
+            // Get the bit MSB0 (so reversed)
+            let bit = (byte >> (7 - i % 8)) & 1;
+
+            // We still need to store in normal order, so we need to reverse again, but within the index
+            let (num_mirror_bits, pivot) = if i / 8 == start / 8 {
+                // We are in the start byte
+                let num_mirror_bits = (start + 1).next_multiple_of(8).min(end) - start;
+                let pivot = start + num_mirror_bits / 2;
+
+                (num_mirror_bits, pivot)
+            } else {
+                // We are in the end byte
+                let num_mirror_bits = end - (end - 8).next_multiple_of(8);
+                let pivot = end - ((num_mirror_bits + 1) / 2);
+
+                (num_mirror_bits, pivot)
+            };
+
+            let mut diff = pivot as isize - i as isize;
+
+            if diff <= 0 && num_mirror_bits % 2 == 0 {
+                diff -= 1;
+            }
+
+            let j = i as isize + diff * 2 - ((num_mirror_bits % 2 == 0) as isize) * diff.signum();
+
+            output |= T::from(bit) << (j as usize - start);
+            i += 1;
+        }
+    }
+
+    output
 }
 
 pub struct LE;
@@ -46,55 +76,31 @@ pub struct BE;
 
 pub trait ByteOrder {
     type Opposite: ByteOrder;
-    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8;
+
+    fn get_byte_index(data_len: usize, bit_index: usize) -> usize;
+    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8 {
+        *data.get_unchecked(Self::get_byte_index(data.len(), bit_index))
+    }
 }
 
 impl ByteOrder for LE {
     type Opposite = BE;
 
-    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8 {
-        *data.get_unchecked(bit_index / 8)
+    fn get_byte_index(_data_len: usize, bit_index: usize) -> usize {
+        bit_index / 8
     }
 }
 
 impl ByteOrder for BE {
     type Opposite = LE;
 
-    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8 {
-        *data.get_unchecked(data.len() - (bit_index / 8) - 1)
+    fn get_byte_index(data_len: usize, bit_index: usize) -> usize {
+        data_len - (bit_index / 8) - 1
     }
 }
 
-pub trait SwapBytes {
-    fn swap_bytes(self) -> Self;
-}
-
-macro_rules! impl_swap_bytes {
-    ($integer:ty) => {
-        impl SwapBytes for $integer {
-            fn swap_bytes(self) -> Self {
-                <$integer>::swap_bytes(self)
-            }
-        }
-    };
-}
-
-impl_swap_bytes!(u8);
-impl_swap_bytes!(u16);
-impl_swap_bytes!(u32);
-impl_swap_bytes!(u64);
-impl_swap_bytes!(u128);
-
-impl_swap_bytes!(i8);
-impl_swap_bytes!(i16);
-impl_swap_bytes!(i32);
-impl_swap_bytes!(i64);
-impl_swap_bytes!(i128);
-
 #[cfg(test)]
 mod tests {
-    use bitvec::view::BitView;
-
     use super::*;
 
     #[test]
@@ -151,8 +157,8 @@ mod tests {
     fn same_as_bitvec() {
         use bitvec::{field::BitField, view::BitView};
 
-        for _ in 0..1_000 {
-            let mut data = vec![0u8; rand::random_range(2..=2)];
+        for _ in 0..1_000_000 {
+            let mut data = vec![0u8; rand::random_range(1..=16)];
             rand::fill(&mut data[..]);
             let mut reversed_data = data.clone();
             reversed_data.reverse();
@@ -164,32 +170,30 @@ mod tests {
 
             println!("{start}..{end} @ {:#010b}", Bytes(&data));
 
-            // let test_value = unsafe { load_lsb0::<u32, LE>(&data, start, end) };
-            // let check_value = data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
-            // println!("LE Lsb0: {:08b} *", Bytes(&check_value.to_be_bytes()));
-            // println!("LE Lsb0: {:08b}", Bytes(&test_value.to_be_bytes()));
-            // assert_eq!(test_value, check_value);
+            let test_value = unsafe { load_lsb0::<u32, LE>(&data, start, end) };
+            let check_value = data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
+            println!("LE Lsb0: {:016b} *", check_value);
+            println!("LE Lsb0: {:016b}", test_value);
+            assert_eq!(test_value, check_value);
 
-            // let test_value = unsafe { load_lsb0::<u32, BE>(&data, start, end) };
-            // let check_value =
-            //     reversed_data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
-            // println!("BE Lsb0: {:08b} *", Bytes(&check_value.to_be_bytes()));
-            // println!("BE Lsb0: {:08b}", Bytes(&test_value.to_be_bytes()));
-            // assert_eq!(test_value, check_value);
+            let test_value = unsafe { load_lsb0::<u32, BE>(&data, start, end) };
+            let check_value =
+                reversed_data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
+            println!("BE Lsb0: {:016b} *", check_value);
+            println!("BE Lsb0: {:016b}", test_value);
+            assert_eq!(test_value, check_value);
 
             let test_value_le_msb0 = unsafe { load_msb0::<u32, LE>(&data, start, end) };
-            let check_value_le_msb0 = data.view_bits::<bitvec::order::Msb0>()[start..end].load_le::<u32>();
-            println!("LE Msb0: {:08b} *", Bytes(&check_value_le_msb0.to_be_bytes()));
-            println!("LE Msb0: {:08b}", Bytes(&test_value_le_msb0.to_be_bytes()));
+            let check_value_le_msb0 =
+                data.view_bits::<bitvec::order::Msb0>()[start..end].load_le::<u32>();
+            println!("LE Msb0: {:016b} *", check_value_le_msb0);
+            println!("LE Msb0: {:016b}", test_value_le_msb0);
 
             let test_value_be_msb0 = unsafe { load_msb0::<u32, BE>(&data, start, end) };
             let check_value_be_msb0 =
                 reversed_data.view_bits::<bitvec::order::Msb0>()[start..end].load_le::<u32>();
-            println!(
-                "BE Msb0: {:08b} *",
-                Bytes(&check_value_be_msb0.to_be_bytes())
-            );
-            println!("BE Msb0: {:08b}", Bytes(&test_value_be_msb0.to_be_bytes()));
+            println!("BE Msb0: {:016b} *", check_value_be_msb0);
+            println!("BE Msb0: {:016b}", test_value_be_msb0);
 
             assert_eq!(test_value_le_msb0, check_value_le_msb0);
             assert_eq!(test_value_be_msb0, check_value_be_msb0);

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -6,10 +6,12 @@ use core::ops::{BitOrAssign, Shl, Shr};
 /// ## Safety:
 ///
 /// `start` and `end` must lie in the range `0..data.len()*8`.
+#[inline(always)]
 pub unsafe fn load_lsb0<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
 where
     T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign + DedupCast,
 {
+    #[inline(never)]
     unsafe fn inner<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
     where
         T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign,
@@ -49,10 +51,12 @@ where
 /// ## Safety:
 ///
 /// `start` and `end` must lie in the range `0..data.len()*8`.
+#[inline(always)]
 pub unsafe fn store_lsb0<T, ByteO: ByteOrder>(value: T, start: usize, end: usize, data: &mut [u8])
 where
     T: Copy + TruncateToU8 + Shr<usize, Output = T> + DedupCast,
 {
+    #[inline(never)]
     unsafe fn inner<T, ByteO: ByteOrder>(value: T, start: usize, end: usize, data: &mut [u8])
     where
         T: Copy + TruncateToU8 + Shr<usize, Output = T>,
@@ -93,10 +97,12 @@ where
 /// ## Safety:
 ///
 /// `start` and `end` must lie in the range `0..data.len()*8`.
+#[inline(always)]
 pub unsafe fn load_msb0<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
 where
     T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign + DedupCast,
 {
+    #[inline(never)]
     unsafe fn inner<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
     where
         T: Default + From<u8> + Shl<usize, Output = T> + BitOrAssign,
@@ -118,54 +124,7 @@ where
             } else {
                 // Move bit by bit
 
-                // We are doing msb0, so the indexing is reversed. However, we still need to store
-                // the data in normal order. So we need to reverse the bits ourselves too.
-                // We can't reverse the whole byte because then the bits end up in the wrong places.
-                // So we reverse around a pivot and the pivot is in the middle of the bits that need
-                // to be reversed.
-                let (num_bits, pivot) = if i / 8 == start / 8 {
-                    // We are in the start byte
-
-                    // The number of bits we're dealing with is the difference between the start and the
-                    // first byte-aligned index or the end, whichever comes first
-                    let num_bits = (start + 1).next_multiple_of(8).min(end) - start;
-                    let pivot = start + num_bits / 2;
-
-                    (num_bits, pivot)
-                } else {
-                    // We are in the end byte
-
-                    // The number of bits we're dealing with is the difference between the last aligned
-                    // bit index and the end
-                    let num_bits = end - (end - 8).next_multiple_of(8);
-                    // Calculate the pivot and force it to round down so any error is in the same direction
-                    // as in the start byte case
-                    let pivot = end - ((num_bits + 1) / 2);
-
-                    (num_bits, pivot)
-                };
-                let num_bits_even = num_bits % 2 == 0;
-
-                // Calculate how far away our current bit is from the pivot.
-                let mut diff = pivot as isize - i as isize;
-
-                if diff <= 0 {
-                    // If we have an even number of bits, we should not have a diff of 0
-                    diff -= num_bits_even as isize;
-                }
-
-                // To do the reversing, we need to move the index towards the pivot
-                // and then keep going the same distance again
-                let mut j = i as isize + diff * 2;
-
-                // Due to integer math, the pivot may not be exactly in the middle, so we need to correct for that.
-                // The pivot is off by a half if we have an even number of bits.
-                // But we've done a `* 2` previously now, so we can correct the half-error with a whole number.
-                if diff > 0 {
-                    j -= 1 * num_bits_even as isize;
-                } else {
-                    j += 1 * num_bits_even as isize;
-                }
+                let j = pivot_msb0(start, end, i);
 
                 // Get the bit MSB0 (so reversed)
                 // Move the target bit all the way to the right so we know where it is
@@ -180,6 +139,111 @@ where
     }
 
     T::cast_back(inner::<T::DedupType, ByteO>(data, start, end))
+}
+
+/// Store an integer into byte slice located at the `start`..`end` range.
+/// The integer is stored with the [LE] or [BE] byte order generic param and using msb0 bit order.
+/// This is more expensive than the [store_lsb0] function.
+///
+/// ## Safety:
+///
+/// `start` and `end` must lie in the range `0..data.len()*8`.
+#[inline(always)]
+pub unsafe fn store_msb0<T, ByteO: ByteOrder>(value: T, start: usize, end: usize, data: &mut [u8])
+where
+    T: Copy + TruncateToU8 + Shr<usize, Output = T> + DedupCast,
+{
+    #[inline(never)]
+    unsafe fn inner<T, ByteO: ByteOrder>(value: T, start: usize, end: usize, data: &mut [u8])
+    where
+        T: Copy + TruncateToU8 + Shr<usize, Output = T>,
+    {
+        // Iterate over the bits, while retaining index control
+        let mut i = start;
+        while i < end {
+            // Get the proper byte we should be looking at
+            let byte = ByteO::get_byte_from_index_mut(data, i);
+
+            if (i % 8 == 0) & (i + 8 <= end) {
+                // We are byte aligned and have a full byte of space left
+                // Do a whole byte in one go for extra performance
+                *byte = (value >> (i - start)).truncate();
+                i += 8;
+            } else {
+                // Move bit by bit
+
+                let j = pivot_msb0(start, end, i);
+
+                // Get the bit MSB0 (so reversed)
+                // Move the target bit all the way to the right so we know where it is
+                let bit = (value >> (j - start)).truncate() & 1;
+
+                // Clear the bit
+                *byte &= !(1 << (7 - i % 8));
+                // If the bit is set, set the bit in the byte
+                // Not if statement here since this is faster and smaller
+                *byte |= bit << (7 - i % 8);
+
+                i += 1;
+            }
+        }
+    }
+
+    inner::<T::DedupType, ByteO>(value.cast(), start, end, data)
+}
+
+#[inline]
+fn pivot_msb0(start: usize, end: usize, i: usize) -> usize {
+    // We are doing msb0, so the indexing is reversed. However, we still need to store
+    // the data in normal order. So we need to reverse the bits ourselves too.
+    // We can't reverse the whole byte because then the bits end up in the wrong places.
+    // So we reverse around a pivot and the pivot is in the middle of the bits that need
+    // to be reversed.
+    let (num_bits, pivot) = if i / 8 == start / 8 {
+        // We are in the start byte
+
+        // The number of bits we're dealing with is the difference between the start and the
+        // first byte-aligned index or the end, whichever comes first
+        let num_bits = (start + 1).next_multiple_of(8).min(end) - start;
+        let pivot = start + num_bits / 2;
+
+        (num_bits, pivot)
+    } else {
+        // We are in the end byte
+
+        // The number of bits we're dealing with is the difference between the last aligned
+        // bit index and the end
+        let num_bits = end - (end - 8).next_multiple_of(8);
+        // Calculate the pivot and force it to round down so any error is in the same direction
+        // as in the start byte case
+        let pivot = end - ((num_bits + 1) / 2);
+
+        (num_bits, pivot)
+    };
+    let num_bits_even = num_bits % 2 == 0;
+
+    // Calculate how far away our current bit is from the pivot.
+    let mut diff = pivot as isize - i as isize;
+
+    if diff <= 0 {
+        // If we have an even number of bits, we should not have a diff of 0
+        diff -= num_bits_even as isize;
+    }
+
+    // To do the reversing, we need to move the index towards the pivot
+    // and then keep going the same distance again
+    let mut j = i as isize + diff * 2;
+
+    // Due to integer math, the pivot may not be exactly in the middle, so we need to correct for that.
+    // The pivot is off by a half if we have an even number of bits.
+    // But we've done a `* 2` previously now, so we can correct the half-error with a whole number.
+    if diff > 0 {
+        j -= 1 * num_bits_even as isize;
+    } else {
+        j += 1 * num_bits_even as isize;
+    }
+
+    j as usize
 }
 
 /// Little endian byte order
@@ -362,7 +426,7 @@ mod tests {
         use bitvec::{field::BitField, view::BitView};
 
         for _ in 0..10_000 {
-            let mut data = vec![0u8; rand::random_range(1..=1)];
+            let mut data = vec![0u8; rand::random_range(1..=16)];
             rand::fill(&mut data[..]);
             let mut reversed_data = data.clone();
             reversed_data.reverse();
@@ -389,9 +453,27 @@ mod tests {
             unsafe { store_lsb0::<_, BE>(input_data, start, end, &mut test_data) };
             let mut check_data = reversed_data.clone();
             check_data.view_bits_mut::<bitvec::order::Lsb0>()[start..end].store_le(input_data);
+            check_data.reverse();
             println!("BE Lsb0: {:#010b} *", Bytes(&check_data));
             println!("BE Lsb0: {:#010b}", Bytes(&test_data));
             assert_eq!(test_data, check_data);
+
+            let mut test_data = data.clone();
+            unsafe { store_msb0::<_, LE>(input_data, start, end, &mut test_data) };
+            let mut check_data = data.clone();
+            check_data.view_bits_mut::<bitvec::order::Msb0>()[start..end].store_le(input_data);
+            println!("LE Msb0: {:#010b} *", Bytes(&check_data));
+            println!("LE Msb0: {:#010b}", Bytes(&test_data));
+
+            let mut test_data1 = data.clone();
+            unsafe { store_msb0::<_, BE>(input_data, start, end, &mut test_data1) };
+            let mut check_data1 = reversed_data.clone();
+            check_data1.view_bits_mut::<bitvec::order::Msb0>()[start..end].store_le(input_data);
+            check_data1.reverse();
+            println!("BE Msb0: {:#010b} *", Bytes(&check_data1));
+            println!("BE Msb0: {:#010b}", Bytes(&test_data1));
+            assert_eq!(test_data, check_data);
+            assert_eq!(test_data1, check_data1);
         }
     }
 }

--- a/device-driver/src/ops.rs
+++ b/device-driver/src/ops.rs
@@ -1,0 +1,152 @@
+use core::ops::{BitAnd, BitOrAssign, Shl, Shr};
+
+pub unsafe fn load_lsb0<T, ByteO: ByteOrder>(data: &[u8], start: usize, end: usize) -> T
+where
+    T: Default
+        + From<u8>
+        + Shr<usize, Output = T>
+        + BitAnd<T, Output = T>
+        + Shl<usize, Output = T>
+        + BitOrAssign,
+{
+    let mut output = T::default();
+
+    let mut i = start;
+    while i < end {
+        let byte = ByteO::get_byte_from_index(data, i);
+
+        if (i % 8 == 0) & (i + 8 <= end) {
+            output |= T::from(byte) << (i - start);
+            i += 8;
+        } else {
+            let bit = (byte >> i % 8) & 1;
+            output |= T::from(bit) << (i - start);
+            i += 1;
+        }
+    }
+
+    output
+}
+
+pub struct LE;
+pub struct BE;
+
+pub trait ByteOrder {
+    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8;
+}
+
+impl ByteOrder for LE {
+    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8 {
+        *data.get_unchecked(bit_index / 8)
+    }
+}
+
+impl ByteOrder for BE {
+    unsafe fn get_byte_from_index(data: &[u8], bit_index: usize) -> u8 {
+        *data.get_unchecked(data.len() - (bit_index / 8) - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_u32_le_lsb0() {
+        unsafe {
+            assert_eq!(
+                load_lsb0::<u32, LE>(&0b11111111111111111111000000u64.to_le_bytes(), 6, 26),
+                0b11111111111111111111
+            );
+            assert_eq!(
+                load_lsb0::<u32, LE>(&0xAABBCCDDEEu64.to_le_bytes(), 8, 32),
+                0xBBCCDD,
+            );
+            assert_eq!(
+                load_lsb0::<u32, LE>(&0xAABBCCDDEEu64.to_le_bytes(), 4, 28),
+                0xBCCDDE,
+            );
+        }
+    }
+
+    #[test]
+    fn test_load_u32_be_lsb0() {
+        unsafe {
+            assert_eq!(
+                load_lsb0::<u32, BE>(&0b11111111111111111111000000u64.to_be_bytes(), 6, 26),
+                0b11111111111111111111
+            );
+            assert_eq!(
+                load_lsb0::<u32, BE>(&0xAABBCCDDEEu64.to_be_bytes(), 8, 32),
+                0xBBCCDD,
+            );
+            assert_eq!(
+                load_lsb0::<u32, BE>(&0xAABBCCDDEEu64.to_be_bytes(), 4, 28),
+                0xBCCDDE,
+            );
+        }
+    }
+
+    struct Bytes<'a>(&'a [u8]);
+
+    impl<'a> std::fmt::Binary for Bytes<'a> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "[")?;
+            for byte in self.0 {
+                std::fmt::Binary::fmt(byte, f)?;
+                write!(f, ",")?;
+            }
+            write!(f, "]")?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn same_as_bitvec() {
+        use bitvec::{field::BitField, view::BitView};
+
+        for _ in 0..1_000_000 {
+            let mut data = vec![0u8; rand::random_range(1..=16)];
+            rand::fill(&mut data[..]);
+            let mut reversed_data = data.clone();
+            reversed_data.reverse();
+
+            let total_bits = data.len() * 8;
+
+            let start = rand::random_range(0..total_bits - 1);
+            let end = start + rand::random_range(1..=total_bits - start).min(32);
+
+            println!("{start}..{end} @ {:#010b}", Bytes(&data));
+
+            let test_value = unsafe { load_lsb0::<u32, LE>(&data, start, end) };
+            let check_value = data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
+            println!("LE Lsb0: {:08b} *", Bytes(&check_value.to_be_bytes()));
+            println!("LE Lsb0: {:08b}", Bytes(&test_value.to_be_bytes()));
+            assert_eq!(test_value, check_value);
+
+            let test_value = unsafe { load_lsb0::<u32, BE>(&data, start, end) };
+            let check_value =
+                reversed_data.view_bits::<bitvec::order::Lsb0>()[start..end].load_le::<u32>();
+            println!("BE Lsb0: {:08b} *", Bytes(&check_value.to_be_bytes()));
+            println!("BE Lsb0: {:08b}", Bytes(&test_value.to_be_bytes()));
+            assert_eq!(test_value, check_value);
+
+            // let test_value_le_msb0 = unsafe { load_msb0::<u32, LE>(&data, start, end) };
+            // let check_value_le_msb0 = data.view_bits::<bitvec::order::Msb0>()[start..end].load_le::<u32>();
+            // println!("LE Msb0: {:08b} *", Bytes(&check_value_le_msb0.to_be_bytes()));
+            // println!("LE Msb0: {:08b}", Bytes(&test_value_le_msb0.to_be_bytes()));
+
+            // let test_value_be_msb0 = unsafe { load_msb0::<u32, BE>(&data, start, end) };
+            // let check_value_be_msb0 =
+            //     reversed_data.view_bits::<bitvec::order::Msb0>()[start..end].load_le::<u32>();
+            // println!(
+            //     "BE Msb0: {:08b} *",
+            //     Bytes(&check_value_be_msb0.to_be_bytes())
+            // );
+            // println!("BE Msb0: {:08b}", Bytes(&test_value_be_msb0.to_be_bytes()));
+
+            // assert_eq!(test_value_le_msb0, check_value_le_msb0);
+            // assert_eq!(test_value_be_msb0, check_value_be_msb0);
+        }
+    }
+}

--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -135,7 +135,7 @@ where
             Register::SIZE_BITS,
             register.get_inner_buffer_mut(),
         )?;
-        Ok(register.into())
+        Ok(register)
     }
 }
 
@@ -161,8 +161,8 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'i, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, Register: FieldSet, Access>
+    RegisterOperation<'_, Interface, AddressType, Register, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: WriteCapability,
@@ -208,8 +208,8 @@ where
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'i, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, Register: FieldSet, Access>
+    RegisterOperation<'_, Interface, AddressType, Register, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: ReadCapability,
@@ -225,12 +225,12 @@ where
                 register.get_inner_buffer_mut(),
             )
             .await?;
-        Ok(register.into())
+        Ok(register)
     }
 }
 
-impl<'i, Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'i, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, Register: FieldSet, Access>
+    RegisterOperation<'_, Interface, AddressType, Register, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: ReadCapability + WriteCapability,

--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -94,9 +94,11 @@ where
         let mut register = (self.register_new_with_reset)();
         let returned = f(&mut register);
 
-        let buffer = Register::BUFFER::from(register);
-        self.interface
-            .write_register(self.address, Register::SIZE_BITS, buffer.as_ref())?;
+        self.interface.write_register(
+            self.address,
+            Register::SIZE_BITS,
+            register.get_inner_buffer(),
+        )?;
         Ok(returned)
     }
 
@@ -112,7 +114,7 @@ where
         self.interface.write_register(
             self.address,
             Register::SIZE_BITS,
-            Register::BUFFER::from(register).as_mut(),
+            register.get_inner_buffer_mut(),
         )?;
         Ok(returned)
     }
@@ -126,11 +128,14 @@ where
 {
     /// Read the register from the device
     pub fn read(&mut self) -> Result<Register, Interface::Error> {
-        let mut buffer = Register::BUFFER::from(Register::new_with_zero());
+        let mut register = Register::new_with_zero();
 
-        self.interface
-            .read_register(self.address, Register::SIZE_BITS, buffer.as_mut())?;
-        Ok(buffer.into())
+        self.interface.read_register(
+            self.address,
+            Register::SIZE_BITS,
+            register.get_inner_buffer_mut(),
+        )?;
+        Ok(register.into())
     }
 }
 
@@ -150,7 +155,7 @@ where
         self.interface.write_register(
             self.address,
             Register::SIZE_BITS,
-            Register::BUFFER::from(register).as_mut(),
+            register.get_inner_buffer_mut(),
         )?;
         Ok(returned)
     }
@@ -173,9 +178,12 @@ where
         let mut register = (self.register_new_with_reset)();
         let returned = f(&mut register);
 
-        let buffer = Register::BUFFER::from(register);
         self.interface
-            .write_register(self.address, Register::SIZE_BITS, buffer.as_ref())
+            .write_register(
+                self.address,
+                Register::SIZE_BITS,
+                register.get_inner_buffer(),
+            )
             .await?;
         Ok(returned)
     }
@@ -193,7 +201,7 @@ where
             .write_register(
                 self.address,
                 Register::SIZE_BITS,
-                Register::BUFFER::from(register).as_mut(),
+                register.get_inner_buffer_mut(),
             )
             .await?;
         Ok(returned)
@@ -208,12 +216,16 @@ where
 {
     /// Read the register from the device
     pub async fn read_async(&mut self) -> Result<Register, Interface::Error> {
-        let mut buffer = Register::BUFFER::from(Register::new_with_zero());
+        let mut register = Register::new_with_zero();
 
         self.interface
-            .read_register(self.address, Register::SIZE_BITS, buffer.as_mut())
+            .read_register(
+                self.address,
+                Register::SIZE_BITS,
+                register.get_inner_buffer_mut(),
+            )
             .await?;
-        Ok(buffer.into())
+        Ok(register.into())
     }
 }
 
@@ -237,7 +249,7 @@ where
             .write_register(
                 self.address,
                 Register::SIZE_BITS,
-                Register::BUFFER::from(register).as_mut(),
+                register.get_inner_buffer(),
             )
             .await?;
         Ok(returned)

--- a/device-driver/tests/bit-ops.rs
+++ b/device-driver/tests/bit-ops.rs
@@ -1,0 +1,73 @@
+device_driver::create_device!(
+    device_name: MyTestDevice,
+    dsl: {
+        config {
+            type RegisterAddressType = u8;
+            type DefaultByteOrder = LE;
+        }
+        register Foo {
+            const ADDRESS = 0;
+            const SIZE_BITS = 32;
+            const RESET_VALUE = 0xFFFFFFFF;
+
+            value: uint = 0..32,
+        },
+    }
+);
+
+#[cfg(test)]
+mod tests {
+    use super::field_sets::Foo;
+
+    #[test]
+    fn and() {
+        assert_eq!(Foo::new() & Foo::new_zero(), Foo::new_zero());
+
+        let mut test_foo = Foo::new_zero();
+        test_foo.set_value(0x12345678);
+
+        assert_eq!(Foo::new() & test_foo, test_foo);
+        assert_eq!(test_foo & Foo::new_zero(), Foo::new_zero());
+
+        test_foo &= Foo::new_zero();
+
+        assert_eq!(test_foo, Foo::new_zero());
+    }
+
+    #[test]
+    fn or() {
+        assert_eq!(Foo::new_zero() | Foo::new(), Foo::new());
+
+        let mut test_foo = Foo::new_zero();
+        test_foo.set_value(0x12345678);
+
+        assert_eq!(Foo::new_zero() | test_foo, test_foo);
+        assert_eq!(test_foo | Foo::new(), Foo::new());
+
+        test_foo |= Foo::new();
+
+        assert_eq!(test_foo, Foo::new());
+    }
+
+    #[test]
+    fn xor() {
+        assert_eq!(Foo::new_zero() ^ Foo::new(), Foo::new());
+        assert_eq!(Foo::new_zero() ^ Foo::new() ^ Foo::new(), Foo::new_zero());
+
+        let mut test_foo = Foo::new_zero();
+        test_foo.set_value(0x12345678);
+
+        assert_eq!(Foo::new_zero() ^ test_foo, test_foo);
+        assert_eq!(test_foo ^ Foo::new(), !test_foo);
+
+        test_foo ^= test_foo;
+
+        assert_eq!(test_foo, Foo::new_zero());
+    }
+
+    #[test]
+    fn not() {
+        assert_eq!(!Foo::new_zero(), Foo::new());
+        assert_eq!(!Foo::new(), Foo::new_zero());
+    }
+}

--- a/device-driver/tests/endianness-respected.rs
+++ b/device-driver/tests/endianness-respected.rs
@@ -6,7 +6,6 @@ impl RegisterInterface for DeviceInterface {
     type Error = ();
     type AddressType = u8;
 
-    #[track_caller]
     fn write_register(
         &mut self,
         _address: Self::AddressType,

--- a/generation/Cargo.toml
+++ b/generation/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.86"
-convert_case = "0.6.0"
+convert_case = "0.6.0" # Out of date, but can't really update in a back-compat way. Fine though, no exploits known in this version
 itertools = "0.14.0"
 proc-macro2 = "1.0.70"
 quote = "1.0.33"


### PR DESCRIPTION
Fixes #59 

Replaced bitvec with custom logic.
Gives some nice size savings (~1.5kB or 7% for my S2-LP driver examples) and it's only a little bit slower.

Other major thing that changed is that the new custom logic operates on bytes in any byte order. Bitvec requires the buffers to all be little endian. So there's no more reversing of bytes in the generated code, so any lost performance is likely made up by that.