### PR TITLE
Make driver name more lenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- The driver name input is now a bit less strict about what 'PascalCase' means
+  - It now also gives a value based on the input that would be accepted
+
 ### 1.0.3 (08-02-25)
 
 - *(Technically breaking)*: removed the `pub use bitvec;` in the root of the crate.


### PR DESCRIPTION
Fixes #62

The driver name input is now a bit less strict about what 'PascalCase' means.

I didn't go with the suggestion of #62 and go with using `convert_case` because it's way less code.