### PR TITLE
Add enum conversions to repeats

### DIFF
--- a/book/src/dsl-syntax.md
+++ b/book/src/dsl-syntax.md
@@ -111,9 +111,9 @@ _FieldList_:
 
 _Field_:
 > _AttributeList_  
-> _IDENTIFIER_`:` _Access_? _BaseType_ _FieldConversion_? `=` _FieldAddress_
+> _IDENTIFIER_`:` _Access_? _BaseType_ _Conversion_? `=` _FieldAddress_
 
-_FieldConversion_:
+_Conversion_:
 > (`as` `try`? _TYPE_PATH_)  
 > | (`as` `try`? `enum` _IDENTIFIER_ `{` _EnumVariantList_`}`)
 
@@ -159,7 +159,11 @@ If no in fields, then no data is sent. If no out fields, then no data is returne
 > | (`const` `ALLOW_ADDRESS_OVERLAP` = _BOOL_`;`)
 
 _Repeat_:
-> `REPEAT` `=` `{` `count` `:` _INTEGER_`,` `stride` `:` _INTEGER_`,`? `}` `;`
+> `REPEAT` `=` `{` `count` `:` _RepeatCount_ `,` `stride` `:` _INTEGER_`,`? `}` `;`
+
+_RepeatCount_
+> _INTEGER_
+> | `usize` _Conversion_
 
 _Buffer_:
 > _AttributeList_  

--- a/book/src/manifest-syntax.md
+++ b/book/src/manifest-syntax.md
@@ -123,9 +123,17 @@ _Block_:
 _Repeat_:
 ```
 {
-    count: uint,
+    count: _RepeatCount_,
     stride: int
 }
+```
+
+_RepeatCount_:
+```
+oneof(
+    uint,
+    _Conversion_
+)
 ```
 
 _Register_:
@@ -156,8 +164,8 @@ _Field_:
     description?: string,
     access?: _Access_,
     base: _BaseType_,
-    conversion?: _FieldConversion_,
-    try_conversion?: _FieldConversion_,
+    conversion?: _Conversion_,
+    try_conversion?: _Conversion_,
     start: int,
     end?: int,
 }
@@ -168,7 +176,7 @@ _BaseType_:
 string oneof("bool", "int", "uint")
 ```
 
-_FieldConversion_:
+_Conversion_:
 ```
 oneof(
     string,

--- a/device-driver/tests/repeat_conversions.rs
+++ b/device-driver/tests/repeat_conversions.rs
@@ -1,0 +1,111 @@
+use device_driver::RegisterInterface;
+
+pub struct DeviceInterface {
+    device_memory: [u8; 128],
+}
+
+impl Default for DeviceInterface {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceInterface {
+    pub const fn new() -> Self {
+        Self {
+            device_memory: [0; 128],
+        }
+    }
+}
+
+impl RegisterInterface for DeviceInterface {
+    type Error = ();
+    type AddressType = u8;
+
+    fn write_register(
+        &mut self,
+        address: Self::AddressType,
+        _size_bits: u32,
+        data: &[u8],
+    ) -> Result<(), Self::Error> {
+        self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
+
+        Ok(())
+    }
+
+    fn read_register(
+        &mut self,
+        address: Self::AddressType,
+        _size_bits: u32,
+        data: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
+        Ok(())
+    }
+}
+
+device_driver::create_device!(
+    device_name: MyTestDevice,
+    dsl: {
+        config {
+            type RegisterAddressType = u8;
+        }
+        register FooRepeated {
+            const ADDRESS = 3;
+            const SIZE_BITS = 8;
+            const REPEAT = {
+                count: usize as enum Blah {
+                    A, B, C = 5, D = 4,
+                },
+                stride: 3,
+            };
+
+            value: uint = 0..8,
+        },
+        ref FooRef = register FooRepeated {
+            const ADDRESS = 4; // Note: Address overlap checking is very limited when using repeat count
+        },
+        ref FooRefExtra = register FooRepeated {
+            const ADDRESS = 5;
+            const REPEAT = {
+                count: usize as CustomIndex,
+                stride: 3,
+            };
+        }
+    }
+);
+
+pub enum CustomIndex {
+    A,
+    B,
+}
+
+impl From<CustomIndex> for usize {
+    fn from(value: CustomIndex) -> Self {
+        match value {
+            CustomIndex::A => 0,
+            CustomIndex::B => 1,
+        }
+    }
+}
+
+#[test]
+fn test_repeated_read_modify_write() {
+    let mut device = MyTestDevice::new(DeviceInterface::new());
+    device
+        .foo_repeated(Blah::C)
+        .modify(|reg| {
+            reg.set_value(12);
+        })
+        .unwrap();
+
+    device
+        .foo_ref_extra(CustomIndex::B)
+        .modify(|reg| {
+            reg.set_value(42);
+        })
+        .unwrap();
+
+    assert_eq!(device.interface.device_memory[18], 12);
+    assert_eq!(device.interface.device_memory[8], 42);
+}

--- a/generation/src/lir/mod.rs
+++ b/generation/src/lir/mod.rs
@@ -38,7 +38,15 @@ pub struct BlockMethod {
 
 pub enum BlockMethodKind {
     Normal,
-    Repeated { count: Literal, stride: Literal },
+    RepeatedNumber {
+        count: Literal,
+        stride: Literal,
+    },
+    /// Repeat from a type that implements `Into<usize>`
+    RepeatedFromType {
+        path: TokenStream,
+        stride: Literal,
+    },
 }
 
 pub enum BlockMethodType {
@@ -81,11 +89,11 @@ pub struct Field {
     pub name: Ident,
     pub address: Range<Literal>,
     pub base_type: Ident,
-    pub conversion_method: FieldConversionMethod,
+    pub conversion_method: ConversionMethod,
     pub access: mir::Access,
 }
 
-pub enum FieldConversionMethod {
+pub enum ConversionMethod {
     None,
     Into(TokenStream),
     UnsafeInto(TokenStream),
@@ -93,14 +101,14 @@ pub enum FieldConversionMethod {
     Bool,
 }
 
-impl FieldConversionMethod {
+impl ConversionMethod {
     pub fn conversion_type(&self) -> Option<&TokenStream> {
         match self {
-            FieldConversionMethod::None => None,
-            FieldConversionMethod::Into(token_stream) => Some(token_stream),
-            FieldConversionMethod::UnsafeInto(token_stream) => Some(token_stream),
-            FieldConversionMethod::TryInto(token_stream) => Some(token_stream),
-            FieldConversionMethod::Bool => None,
+            ConversionMethod::None => None,
+            ConversionMethod::Into(token_stream) => Some(token_stream),
+            ConversionMethod::UnsafeInto(token_stream) => Some(token_stream),
+            ConversionMethod::TryInto(token_stream) => Some(token_stream),
+            ConversionMethod::Bool => None,
         }
     }
 }

--- a/generation/src/lir/passes/addresses_non_overlapping.rs
+++ b/generation/src/lir/passes/addresses_non_overlapping.rs
@@ -53,11 +53,13 @@ fn get_block_claimed_addresses(
 
         let (repeat_count, repeat_stride, repeat): (i64, i64, bool) = match &method.kind {
             BlockMethodKind::Normal => (1, 0, false),
-            BlockMethodKind::Repeated { count, stride } => (
+            BlockMethodKind::RepeatedNumber { count, stride } => (
                 count.to_string().parse().unwrap(),
                 stride.to_string().parse().unwrap(),
                 true,
             ),
+            // We don't know the possibilities of this type, so we can't really check
+            BlockMethodKind::RepeatedFromType { .. } => continue,
         };
 
         let claimed_address_type = match &method.method_type {
@@ -154,7 +156,7 @@ mod tests {
                             name: format_ident!("second_block"),
                             address: Literal::i64_unsuffixed(10),
                             allow_address_overlap: false,
-                            kind: BlockMethodKind::Repeated {
+                            kind: BlockMethodKind::RepeatedNumber {
                                 count: Literal::i64_unsuffixed(10),
                                 stride: Literal::i64_unsuffixed(10),
                             },
@@ -168,7 +170,7 @@ mod tests {
                             name: format_ident!("register0"),
                             address: Literal::i64_unsuffixed(75),
                             allow_address_overlap: false,
-                            kind: BlockMethodKind::Repeated {
+                            kind: BlockMethodKind::RepeatedNumber {
                                 count: Literal::i64_unsuffixed(2),
                                 stride: Literal::i64_unsuffixed(5),
                             },

--- a/generation/src/mir/passes/bool_fields_checked.rs
+++ b/generation/src/mir/passes/bool_fields_checked.rs
@@ -22,7 +22,7 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
                 );
 
                 ensure!(
-                    field.field_conversion.is_none(),
+                    field.conversion.is_none(),
                     "Object \"{}\" has field \"{}\" which is of base type `bool` and has specified a conversion. This is not supported for bools.",
                     object_name,
                     field.name

--- a/generation/src/mir/passes/field_conversion_enum_values_checked.rs
+++ b/generation/src/mir/passes/field_conversion_enum_values_checked.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, ensure};
 use itertools::Itertools;
 
-use crate::mir::{Device, EnumGenerationStyle, EnumValue, FieldConversion, Unique};
+use crate::mir::{Conversion, Device, EnumGenerationStyle, EnumValue, Unique};
 
 use super::recurse_objects_mut;
 
@@ -11,10 +11,10 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
         let object_name = object.name().to_string();
 
         for field in object.field_sets_mut().flatten() {
-            if let Some(FieldConversion::Enum {
+            if let Some(Conversion::Enum {
                 enum_value: ec,
                 use_try,
-            }) = field.field_conversion.as_mut()
+            }) = field.conversion.as_mut()
             {
                 let field_bits = field.field_address.clone().count();
                 let highest_value = (1 << field_bits) - 1;
@@ -148,7 +148,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new(
                             Default::default(),
                             "MyEnum".into(),
@@ -189,7 +189,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new_with_style(
                             Default::default(),
                             "MyEnum".into(),
@@ -238,7 +238,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new(
                             Default::default(),
                             "MyEnum".into(),
@@ -269,7 +269,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new_with_style(
                             Default::default(),
                             "MyEnum".into(),
@@ -308,7 +308,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new(
                             Default::default(),
                             "MyEnum".into(),
@@ -332,7 +332,7 @@ mod tests {
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new_with_style(
                             Default::default(),
                             "MyEnum".into(),
@@ -365,7 +365,7 @@ mod tests {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
                     name: "MyField".into(),
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new(
                             Default::default(),
                             "MyEnum".into(),
@@ -410,7 +410,7 @@ mod tests {
                 name: "MyCommand".into(),
                 out_fields: vec![Field {
                     name: "MyField".into(),
-                    field_conversion: Some(FieldConversion::Enum {
+                    conversion: Some(Conversion::Enum {
                         enum_value: Enum::new(
                             Default::default(),
                             "MyEnum".into(),

--- a/generation/src/mir/passes/names_normalized.rs
+++ b/generation/src/mir/passes/names_normalized.rs
@@ -1,6 +1,6 @@
 use convert_case::Case;
 
-use crate::mir::{Device, Enum, FieldConversion};
+use crate::mir::{Conversion, Device, Enum};
 
 use super::recurse_objects_mut;
 
@@ -23,10 +23,10 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
 
         for field in object.field_sets_mut().flatten() {
             field.name = snake_converter.convert(&field.name);
-            if let Some(FieldConversion::Enum {
+            if let Some(Conversion::Enum {
                 enum_value: Enum { name, variants, .. },
                 ..
-            }) = field.field_conversion.as_mut()
+            }) = field.conversion.as_mut()
             {
                 *name = pascal_converter.convert(&*name);
 
@@ -72,7 +72,7 @@ mod tests {
                         },
                         Field {
                             name: "my-fielD2".into(),
-                            field_conversion: Some(FieldConversion::Enum {
+                            conversion: Some(Conversion::Enum {
                                 enum_value: Enum {
                                     name: "mY-enum".into(),
                                     variants: vec![EnumVariant {
@@ -107,7 +107,7 @@ mod tests {
                         },
                         Field {
                             name: "my_field2".into(),
-                            field_conversion: Some(FieldConversion::Enum {
+                            conversion: Some(Conversion::Enum {
                                 enum_value: Enum {
                                     name: "MyEnum".into(),
                                     variants: vec![EnumVariant {

--- a/generation/src/mir/passes/propagate_cfg.rs
+++ b/generation/src/mir/passes/propagate_cfg.rs
@@ -1,4 +1,4 @@
-use crate::mir::{Cfg, Device, FieldConversion};
+use crate::mir::{Cfg, Conversion, Device};
 
 use super::recurse_objects_with_depth_mut;
 
@@ -22,8 +22,7 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
         for field in object.field_sets_mut().flatten() {
             // NOTE: We don't have to set the field cfg attr since it's part of the object
             // We do need to update the enum though, since that's gonna be generated outside of the object
-            if let Some(FieldConversion::Enum { enum_value, .. }) = field.field_conversion.as_mut()
-            {
+            if let Some(Conversion::Enum { enum_value, .. }) = field.conversion.as_mut() {
                 enum_value.cfg_attr = field.cfg_attr.combine(&new_cfg_attr);
                 // Just like we don't have to update the field cfg, we also don't have to update the enum variant cfgs
             }

--- a/generation/src/mir/passes/repeat_conversion_values_checked.rs
+++ b/generation/src/mir/passes/repeat_conversion_values_checked.rs
@@ -1,0 +1,49 @@
+use anyhow::ensure;
+
+use crate::mir::{Conversion, Device, EnumGenerationStyle, EnumValue};
+
+use super::recurse_objects_mut;
+
+pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
+    recurse_objects_mut(&mut device.objects, &mut |object| {
+        let Some(repeat) = object.repeat_mut() else {
+            return Ok(());
+        };
+
+        match &mut repeat.count {
+            crate::mir::RepeatCount::Value(_) => {}
+            crate::mir::RepeatCount::Conversion(Conversion::Enum {
+                enum_value,
+                use_try,
+            }) => {
+                ensure!(
+                    !*use_try,
+                    "Try conversions are not supported for repeat counts: found in object \"{}\"",
+                    object.name(),
+                );
+
+                enum_value.generation_style = Some(EnumGenerationStyle::Index);
+
+                for variant in &mut enum_value.variants {
+                    ensure!(
+                        matches!(
+                            variant.value,
+                            EnumValue::Unspecified | EnumValue::Specified(_)
+                        ),
+                        "Repeat count conversions don't support 'default' and 'catch-all' variants: found in object \"{}\"",
+                        object.name()
+                    );
+                }
+            }
+            crate::mir::RepeatCount::Conversion(Conversion::Direct { use_try, .. }) => {
+                ensure!(
+                    !*use_try,
+                    "Try conversions are not supported for repeat counts: found in object \"{}\"",
+                    object.name(),
+                );
+            }
+        }
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
Fixes #64 

When using the conversions, you will loose some of the checking of the address overlap