### PR TITLE
Added CLI support to write to stdout

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let output: &mut dyn Write = match &args.output_path {
         Some(path) => &mut std::fs::File::create(path)
-            .unwrap_or_else(|_| panic!("Could not create the output file at: {}", path.display())),
+            .unwrap_or_else(|_| panic!("Could not create the output file at: {}. Does its directory exist?", path.display())),
         None => &mut std::io::stdout().lock(),
     };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ struct Args {
     /// The type of file is determined from the file extension.
     #[arg(short = 'm', long = "manifest", value_name = "FILE")]
     manifest_path: PathBuf,
-    /// Path to output location. Any existing file is overwritten. Defaults to stdout.
+    /// Path to output location. Any existing file is overwritten. If not provided, the output is written to stdout.
     #[arg(short = 'o', long = "output", value_name = "FILE")]
     output_path: Option<PathBuf>,
     /// The name of the device to be generated. Must be PascalCase

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,8 +57,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let pretty_output = prettyplease::unparse(&syn::parse2(output).unwrap());
 
     let output: &mut dyn Write = match &args.output_path {
-        Some(path) => &mut std::fs::File::create(path)
-            .unwrap_or_else(|_| panic!("Could not create the output file at: {}. Does its directory exist?", path.display())),
+        Some(path) => &mut std::fs::File::create(path).unwrap_or_else(|_| {
+            panic!(
+                "Could not create the output file at: {}. Does its directory exist?",
+                path.display()
+            )
+        }),
         None => &mut std::io::stdout().lock(),
     };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::{error::Error, ops::Deref, path::PathBuf};
+use std::{error::Error, io::Write, ops::Deref, path::PathBuf};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -8,9 +8,9 @@ struct Args {
     /// The type of file is determined from the file extension.
     #[arg(short = 'm', long = "manifest", value_name = "FILE")]
     manifest_path: PathBuf,
-    /// Path to output location. Any existing file is overwritten.
+    /// Path to output location. Any existing file is overwritten. Defaults to stdout.
     #[arg(short = 'o', long = "output", value_name = "FILE")]
-    output_path: PathBuf,
+    output_path: Option<PathBuf>,
     /// The name of the device to be generated. Must be PascalCase
     #[arg(short = 'd', long = "device-name", value_name = "NAME")]
     device_name: String,
@@ -56,12 +56,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pretty_output = prettyplease::unparse(&syn::parse2(output).unwrap());
 
-    std::fs::write(&args.output_path, &pretty_output).unwrap_or_else(|_| {
-        panic!(
-            "Could not write the output to: {}",
-            args.output_path.display()
-        )
-    });
+    let output: &mut dyn Write = match &args.output_path {
+        Some(path) => &mut std::fs::File::create(path)
+            .unwrap_or_else(|_| panic!("Could not create the output file at: {}", path.display())),
+        None => &mut std::io::stdout().lock(),
+    };
+
+    let mut output = std::io::BufWriter::new(output);
+    output
+        .write_all(pretty_output.as_bytes())
+        .expect("Could not write the output");
 
     if pretty_output.starts_with("::core::compile_error!") {
         let error_output = pretty_output


### PR DESCRIPTION
If the `--output <FILE>` option is not specified, the CLI will write the output to stdout. This closes #65.

I also improved the error message when creating the output file when `--output <FILE>` is specified to hint the user towards checking if the containing directory exists, which resolves #66.