### PR TITLE
Kdl gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ### Unreleased
 
+- Backend code generation switched from quote/syn to askama
+- Fixed cfg gates on fields (didn't compile before)
 - CLI: When no output file is provided, the output is printed to stdout instead
 - CLI: No longer panics when unexpected error output is processed
 - Error messages now more consistently use backticks (`) instead of various other quoting characters like (') and (")
-- Backend code generation switched from quote/syn to askama
-- Fixed cfg gates on fields (didn't compile before)
+- CLI: Added a new generation option. It defaults to Rust, but can now also be used to generate a KDL manifest
+  - There's no way to use KDL yet, so this is purely a preview feature and the format might change in the future.
+  - In the future this can be used to convert existing specs into KDL.
+  - Possibly eventually this can be used to generate C code instead of Rust
 
 ### 1.0.4 (28-02-25)
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ description = "The command line tool for the device-driver toolkit"
 readme = "README.md"
 
 [dependencies]
+anyhow = "1.0.98"
 clap = { version = "4.5.20", features = ["derive"] }
 device-driver-generation = { version = "=1.0.4", path = "../generation" }
 prettyplease = { version = "0.2.22", features = ["verbatim"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -92,16 +92,16 @@ impl GenType {
             GenType::Rust => {
                 let output = match manifest_type {
                     "json" => {
-                        device_driver_generation::transform_json(&manifest_contents, device_name)
+                        device_driver_generation::transform_json(manifest_contents, device_name)
                     }
                     "yaml" => {
-                        device_driver_generation::transform_yaml(&manifest_contents, device_name)
+                        device_driver_generation::transform_yaml(manifest_contents, device_name)
                     }
                     "toml" => {
-                        device_driver_generation::transform_toml(&manifest_contents, device_name)
+                        device_driver_generation::transform_toml(manifest_contents, device_name)
                     }
                     "dsl" => device_driver_generation::transform_dsl(
-                        syn::parse_str(&manifest_contents).expect("Could not (syn) parse the DSL"),
+                        syn::parse_str(manifest_contents).expect("Could not (syn) parse the DSL"),
                         device_name,
                     ),
                     unknown => panic!(
@@ -114,18 +114,18 @@ impl GenType {
             GenType::Kdl => {
                 let mir_device = match manifest_type {
                     "json" => {
-                        device_driver_generation::_private_transform_json_mir(&manifest_contents)
+                        device_driver_generation::_private_transform_json_mir(manifest_contents)
                     }
                     "yaml" => {
-                        device_driver_generation::_private_transform_yaml_mir(&manifest_contents)
+                        device_driver_generation::_private_transform_yaml_mir(manifest_contents)
                     }
                     "toml" => {
-                        device_driver_generation::_private_transform_toml_mir(&manifest_contents)
+                        device_driver_generation::_private_transform_toml_mir(manifest_contents)
                     }
                     "dsl" => device_driver_generation::_private_transform_dsl_mir(
-                        syn::parse_str(&manifest_contents).expect("Could not (syn) parse the DSL"),
+                        syn::parse_str(manifest_contents).expect("Could not (syn) parse the DSL"),
                     )
-                    .map_err(|e| anyhow::Error::new(e)),
+                    .map_err(anyhow::Error::new),
                     unknown => panic!(
                         "Unknown manifest file extension: '{unknown}'. Only 'dsl', 'json', 'yaml' and 'toml' are allowed."
                     ),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ struct Args {
     #[arg(short = 'd', long = "device-name", value_name = "NAME")]
     device_name: String,
     /// Type of generated output
-    #[arg(short = 'g', long = "gen-type")]
+    #[arg(short = 'g', long = "gen-type", default_value = "rust")]
     gen_type: GenType,
 }
 

--- a/generation/Cargo.toml
+++ b/generation/Cargo.toml
@@ -21,6 +21,7 @@ syn = { version = "2.0", features = ["extra-traits"] }
 bitvec = "1.0.1"
 dd-manifest-tree = { version = "1.0.0", path = "../dd-manifest-tree", optional = true, default-features = false }
 askama = "0.14.0"
+kdl = "6.3.4"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/generation/src/dsl_hir/mir_transform.rs
+++ b/generation/src/dsl_hir/mir_transform.rs
@@ -8,6 +8,7 @@ pub fn transform(device: dsl_hir::Device) -> Result<mir::Device, syn::Error> {
     let objects = transform_object_list(device.object_list, &global_config)?;
 
     Ok(mir::Device {
+        name: None,
         global_config,
         objects,
     })

--- a/generation/src/lib.rs
+++ b/generation/src/lib.rs
@@ -5,7 +5,7 @@ mod dsl_hir;
 mod lir;
 #[cfg(feature = "manifest")]
 mod manifest;
-mod mir;
+pub mod mir;
 
 /// Transform the tokens of the DSL lang to the generated device driver (or a compile error).
 ///

--- a/generation/src/manifest/mod.rs
+++ b/generation/src/manifest/mod.rs
@@ -22,6 +22,7 @@ pub fn transform(value: impl Value) -> anyhow::Result<mir::Device> {
         .collect::<Result<_, _>>()?;
 
     Ok(mir::Device {
+        name: None,
         global_config,
         objects,
     })

--- a/generation/src/mir/kdl_transform.rs
+++ b/generation/src/mir/kdl_transform.rs
@@ -120,13 +120,13 @@ fn transform_object(object: &Object, global_config: &GlobalConfig) -> KdlNode {
         Object::Buffer(_) => ("buffer", None),
         Object::Ref(ref_object) => match &ref_object.object_override {
             ObjectOverride::Block(override_data) => {
-                ("ref", Some(("block-target", override_data.name.clone())))
+                ("ref", Some(("target-block", override_data.name.clone())))
             }
             ObjectOverride::Register(override_data) => {
-                ("ref", Some(("register-target", override_data.name.clone())))
+                ("ref", Some(("target-register", override_data.name.clone())))
             }
             ObjectOverride::Command(override_data) => {
-                ("ref", Some(("command-target", override_data.name.clone())))
+                ("ref", Some(("target-command", override_data.name.clone())))
             }
         },
     };

--- a/generation/src/mir/kdl_transform.rs
+++ b/generation/src/mir/kdl_transform.rs
@@ -261,7 +261,7 @@ fn transform_register(register: &Register, global_config: &GlobalConfig) -> KdlD
         fields_node
             .ensure_children()
             .nodes_mut()
-            .push(transform_field(field));
+            .push(transform_field(field, global_config));
     }
     document.nodes_mut().push(fields_node);
 
@@ -283,7 +283,7 @@ fn transform_repeat_config(repeat: &Repeat) -> KdlNode {
     repeat_node
 }
 
-fn transform_field(field: &Field) -> KdlNode {
+fn transform_field(field: &Field, global_config: &GlobalConfig) -> KdlNode {
     let Field {
         cfg_attr,
         description,
@@ -320,7 +320,9 @@ fn transform_field(field: &Field) -> KdlNode {
         None => node.set_ty(base_type_text),
     }
 
-    node.push(access.to_string());
+    if *access != global_config.default_field_access {
+        node.push(access.to_string());
+    }
 
     if let Some(cfg) = cfg_attr.inner() {
         node.push(("cfg", cfg));
@@ -466,7 +468,7 @@ fn transform_command(command: &Command, global_config: &GlobalConfig) -> KdlDocu
         in_fields_node
             .ensure_children()
             .nodes_mut()
-            .push(transform_field(field));
+            .push(transform_field(field, global_config));
     }
     document.nodes_mut().push(in_fields_node);
 
@@ -474,7 +476,7 @@ fn transform_command(command: &Command, global_config: &GlobalConfig) -> KdlDocu
         out_fields_node
             .ensure_children()
             .nodes_mut()
-            .push(transform_field(field));
+            .push(transform_field(field, global_config));
     }
     document.nodes_mut().push(out_fields_node);
 

--- a/generation/src/mir/kdl_transform.rs
+++ b/generation/src/mir/kdl_transform.rs
@@ -57,64 +57,54 @@ fn transform_global_config(global_config: &GlobalConfig) -> Vec<KdlNode> {
     let mut nodes = Vec::new();
 
     if default_register_access != GlobalConfig::default().default_register_access {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("default-register-access".into()));
+        let mut config_node = KdlNode::new("default-register-access");
         config_node.push(default_register_access.to_string());
         nodes.push(config_node);
     }
     if default_field_access != GlobalConfig::default().default_field_access {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("default-field-access".into()));
+        let mut config_node = KdlNode::new("default-field-access");
         config_node.push(default_field_access.to_string());
         nodes.push(config_node);
     }
     if default_buffer_access != GlobalConfig::default().default_buffer_access {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("default-buffer-access".into()));
+        let mut config_node = KdlNode::new("default-buffer-access");
         config_node.push(default_buffer_access.to_string());
         nodes.push(config_node);
     }
     if let Some(default_byte_order) = default_byte_order {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("default-byte-order".into()));
+        let mut config_node = KdlNode::new("default-byte-order");
         config_node.push(default_byte_order.to_string());
         nodes.push(config_node);
     }
     if default_bit_order != GlobalConfig::default().default_bit_order {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("default-bit-order".into()));
+        let mut config_node = KdlNode::new("default-bit-order");
         config_node.push(default_bit_order.to_string());
         nodes.push(config_node);
     }
     if let Some(register_address_type) = register_address_type {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("register-address-type".into()));
+        let mut config_node = KdlNode::new("register-address-type");
         config_node.push(register_address_type.to_string());
         nodes.push(config_node);
     }
     if let Some(command_address_type) = command_address_type {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("command-address-type".into()));
+        let mut config_node = KdlNode::new("command-address-type");
         config_node.push(command_address_type.to_string());
         nodes.push(config_node);
     }
     if let Some(buffer_address_type) = buffer_address_type {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("buffer-address-type".into()));
+        let mut config_node = KdlNode::new("buffer-address-type");
         config_node.push(buffer_address_type.to_string());
         nodes.push(config_node);
     }
     if name_word_boundaries != GlobalConfig::default().name_word_boundaries {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("name-word-boundaries".into()));
+        let mut config_node = KdlNode::new("name-word-boundaries");
         for boundary in name_word_boundaries {
             config_node.push(format!("{boundary:?}"));
         }
         nodes.push(config_node);
     }
     if let Some(defmt_feature) = defmt_feature {
-        let mut config_node = KdlNode::new("config");
-        config_node.push(KdlValue::String("defmt-feature".into()));
+        let mut config_node = KdlNode::new("defmt-feature");
         config_node.push(defmt_feature);
         nodes.push(config_node);
     }
@@ -182,8 +172,7 @@ fn transform_block(block: &Block, global_config: &GlobalConfig) -> KdlDocument {
         document.nodes_mut().push(cfg_node);
     }
 
-    let mut address_offset_node = KdlNode::new("config");
-    address_offset_node.push("address-offset");
+    let mut address_offset_node = KdlNode::new("address-offset");
     address_offset_node.push(*address_offset as i128);
     document.nodes_mut().push(address_offset_node);
 
@@ -218,57 +207,43 @@ fn transform_register(register: &Register, global_config: &GlobalConfig) -> KdlD
     } = register;
 
     let mut document = KdlDocument::new();
+    let mut fields_node = KdlNode::new("fields");
 
     if let Some(cfg_node) = transform_cfg_config(cfg_attr) {
         document.nodes_mut().push(cfg_node);
     }
 
     if *access != global_config.default_register_access {
-        let mut access_node = KdlNode::new("config");
-        access_node.push("access");
+        let mut access_node = KdlNode::new("access");
         access_node.push(access.to_string());
         document.nodes_mut().push(access_node);
     }
 
     if let Some(byte_order) = byte_order {
-        let mut byte_order_node = KdlNode::new("config");
-        byte_order_node.push("byte-order");
-        byte_order_node.push(byte_order.to_string());
-        document.nodes_mut().push(byte_order_node);
+        fields_node.push(("byte-order", byte_order.to_string()));
     }
 
     if *bit_order != global_config.default_bit_order {
-        let mut bit_order_node = KdlNode::new("config");
-        bit_order_node.push("bit-order");
-        bit_order_node.push(bit_order.to_string());
-        document.nodes_mut().push(bit_order_node);
+        fields_node.push(("bit-order", bit_order.to_string()));
     }
 
     if *allow_bit_overlap {
-        let mut bit_overlap_node = KdlNode::new("config");
-        bit_overlap_node.push("allow-bit-overlap");
-        document.nodes_mut().push(bit_overlap_node);
+        fields_node.push("allow-bit-overlap");
     }
 
     if *allow_address_overlap {
-        let mut address_overlap_node = KdlNode::new("config");
-        address_overlap_node.push("allow-address-overlap");
+        let address_overlap_node = KdlNode::new("allow-address-overlap");
         document.nodes_mut().push(address_overlap_node);
     }
 
-    let mut address_node = KdlNode::new("config");
-    address_node.push("address");
+    let mut address_node = KdlNode::new("address");
     address_node.push(*address as i128);
     document.nodes_mut().push(address_node);
 
-    let mut size_bits_node = KdlNode::new("config");
-    size_bits_node.push("size_bits");
-    size_bits_node.push(*size_bits as i128);
-    document.nodes_mut().push(size_bits_node);
+    fields_node.push(("size_bits", *size_bits as i128));
 
     if let Some(reset_value) = reset_value {
-        let mut reset_value_node = KdlNode::new("config");
-        reset_value_node.push("reset-value");
+        let mut reset_value_node = KdlNode::new("reset-value");
         match reset_value {
             ResetValue::Integer(num) => reset_value_node.push(*num as i128),
             ResetValue::Array(bytes) => {
@@ -285,23 +260,25 @@ fn transform_register(register: &Register, global_config: &GlobalConfig) -> KdlD
     }
 
     for field in fields {
-        document.nodes_mut().push(transform_field(field));
+        fields_node
+            .ensure_children()
+            .nodes_mut()
+            .push(transform_field(field));
     }
+    document.nodes_mut().push(fields_node);
 
     document
 }
 
 fn transform_cfg_config(cfg: &Cfg) -> Option<KdlNode> {
-    let mut cfg_node = KdlNode::new("config");
-    cfg_node.push("cfg");
+    let mut cfg_node = KdlNode::new("cfg");
     cfg_node.push(cfg.inner()?);
 
     Some(cfg_node)
 }
 
 fn transform_repeat_config(repeat: &Repeat) -> KdlNode {
-    let mut repeat_node = KdlNode::new("config");
-    repeat_node.push("repeat");
+    let mut repeat_node = KdlNode::new("repeat");
     repeat_node.push(("count", repeat.count as i128));
     repeat_node.push(("stride", repeat.stride as i128));
 
@@ -397,19 +374,17 @@ fn transform_buffer(buffer: &Buffer, global_config: &GlobalConfig) -> KdlDocumen
 
     let mut document = KdlDocument::new();
 
-    if let Some(cfg_node) = transform_cfg_config(&cfg_attr) {
+    if let Some(cfg_node) = transform_cfg_config(cfg_attr) {
         document.nodes_mut().push(cfg_node);
     }
 
     if *access != global_config.default_buffer_access {
-        let mut node = KdlNode::new("config");
-        node.push("access");
+        let mut node = KdlNode::new("access");
         node.push(access.to_string());
         document.nodes_mut().push(node);
     }
 
-    let mut address_node = KdlNode::new("config");
-    address_node.push("address");
+    let mut address_node = KdlNode::new("address");
     address_node.push(*address as i128);
     document.nodes_mut().push(address_node);
 

--- a/generation/src/mir/mod.rs
+++ b/generation/src/mir/mod.rs
@@ -7,6 +7,7 @@ use convert_case::Boundary;
 
 pub mod lir_transform;
 pub mod passes;
+pub mod kdl_transform;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Device {
@@ -179,6 +180,17 @@ impl Object {
             Object::Command(val) => &val.name,
             Object::Buffer(val) => &val.name,
             Object::Ref(val) => &val.name,
+        }
+    }
+
+    /// Get a reference to the description of the specific object
+    pub(self) fn description(&self) -> &str {
+        match self {
+            Object::Block(val) => &val.description,
+            Object::Register(val) => &val.description,
+            Object::Command(val) => &val.description,
+            Object::Buffer(val) => &val.description,
+            Object::Ref(val) => &val.description,
         }
     }
 

--- a/generation/src/mir/mod.rs
+++ b/generation/src/mir/mod.rs
@@ -10,6 +10,7 @@ pub mod passes;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Device {
+    pub name: Option<String>,
     pub global_config: GlobalConfig,
     pub objects: Vec<Object>,
 }

--- a/generation/src/mir/mod.rs
+++ b/generation/src/mir/mod.rs
@@ -5,9 +5,9 @@ use std::{fmt::Display, ops::Range};
 
 use convert_case::Boundary;
 
+pub mod kdl_transform;
 pub mod lir_transform;
 pub mod passes;
-pub mod kdl_transform;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Device {
@@ -345,10 +345,12 @@ pub struct Field {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BaseType {
+    Unspecified,
     Bool,
     #[default]
     Uint,
     Int,
+    FixedSize(Integer),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/generation/src/mir/passes/address_types_big_enough.rs
+++ b/generation/src/mir/passes/address_types_big_enough.rs
@@ -85,6 +85,7 @@ mod tests {
     #[test]
     fn not_too_low() {
         let mut start_mir = Device {
+            name: None,
             global_config: GlobalConfig {
                 register_address_type: Some(Integer::I8),
                 ..Default::default()
@@ -105,6 +106,7 @@ mod tests {
     #[test]
     fn not_too_high() {
         let mut start_mir = Device {
+            name: None,
             global_config: GlobalConfig {
                 command_address_type: Some(Integer::U16),
                 ..Default::default()

--- a/generation/src/mir/passes/bit_ranges_validated.rs
+++ b/generation/src/mir/passes/bit_ranges_validated.rs
@@ -80,6 +80,7 @@ mod tests {
     #[test]
     fn max_len_exceeded() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyReg".into(),
@@ -96,6 +97,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyReg".into(),
@@ -115,6 +117,7 @@ mod tests {
         );
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -131,6 +134,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -150,6 +154,7 @@ mod tests {
         );
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -166,6 +171,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -188,6 +194,7 @@ mod tests {
     #[test]
     fn overlap_register() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyReg".into(),
@@ -211,6 +218,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyReg".into(),
@@ -235,6 +243,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyReg".into(),
@@ -264,6 +273,7 @@ mod tests {
     #[test]
     fn overlap_command_in() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -287,6 +297,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -311,6 +322,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -340,6 +352,7 @@ mod tests {
     #[test]
     fn overlap_command_out() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -363,6 +376,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),
@@ -387,6 +401,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyReg".into(),

--- a/generation/src/mir/passes/byte_order_specified.rs
+++ b/generation/src/mir/passes/byte_order_specified.rs
@@ -60,6 +60,7 @@ mod tests {
     #[test]
     fn well_enough_specified() {
         let mut input = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![
                 Object::Register(Register {
@@ -98,6 +99,7 @@ mod tests {
     #[test]
     fn not_enough_specified() {
         let mut input = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "MyRegister".into(),
@@ -112,6 +114,7 @@ mod tests {
         );
 
         let mut input = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -126,6 +129,7 @@ mod tests {
         );
 
         let mut input = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -148,6 +152,7 @@ mod tests {
         };
 
         let mut input = Device {
+            name: None,
             global_config,
             objects: vec![
                 Object::Register(Register {

--- a/generation/src/mir/passes/enum_values_checked.rs
+++ b/generation/src/mir/passes/enum_values_checked.rs
@@ -144,6 +144,7 @@ mod tests {
     #[test]
     fn enum_values_correct() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -185,6 +186,7 @@ mod tests {
         };
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -234,6 +236,7 @@ mod tests {
     #[test]
     fn enum_values_infallible_with_fallback() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -265,6 +268,7 @@ mod tests {
         };
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -304,6 +308,7 @@ mod tests {
     #[test]
     fn enum_values_fallible() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -328,6 +333,7 @@ mod tests {
         };
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -360,6 +366,7 @@ mod tests {
     #[test]
     fn enum_values_dont_fit() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),
@@ -405,6 +412,7 @@ mod tests {
     #[test]
     fn enum_values_no_duplicates() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Command(Command {
                 name: "MyCommand".into(),

--- a/generation/src/mir/passes/names_normalized.rs
+++ b/generation/src/mir/passes/names_normalized.rs
@@ -61,6 +61,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config: global_config.clone(),
             objects: vec![
                 Object::Register(Register {
@@ -96,6 +97,7 @@ mod tests {
         };
 
         let end_mir = Device {
+            name: None,
             global_config,
             objects: vec![
                 Object::Register(Register {

--- a/generation/src/mir/passes/names_unique.rs
+++ b/generation/src/mir/passes/names_unique.rs
@@ -77,6 +77,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config,
             objects: vec![
                 Object::Buffer(Buffer {
@@ -102,6 +103,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -133,6 +135,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -180,6 +183,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -219,6 +223,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
+            name: None,
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),

--- a/generation/src/mir/passes/refs_validated.rs
+++ b/generation/src/mir/passes/refs_validated.rs
@@ -80,6 +80,7 @@ mod tests {
     #[test]
     fn ref_found() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![
                 Object::Register(Register {
@@ -104,6 +105,7 @@ mod tests {
     #[test]
     fn bad_register_ref() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Ref(RefObject {
                 cfg_attr: Default::default(),
@@ -125,6 +127,7 @@ mod tests {
     #[test]
     fn bad_block_ref() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Ref(RefObject {
                 cfg_attr: Default::default(),
@@ -146,6 +149,7 @@ mod tests {
     #[test]
     fn bad_command_ref() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Ref(RefObject {
                 cfg_attr: Default::default(),

--- a/generation/src/mir/passes/reset_values_converted.rs
+++ b/generation/src/mir/passes/reset_values_converted.rs
@@ -212,6 +212,7 @@ mod tests {
     #[test]
     fn correct_sizes() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -224,6 +225,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -236,6 +238,7 @@ mod tests {
         assert_eq!(start_mir, end_mir);
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -248,6 +251,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -260,6 +264,7 @@ mod tests {
         assert_eq!(start_mir, end_mir);
 
         let mut start_mir = Device {
+            name: None,
             global_config: GlobalConfig {
                 default_byte_order: Some(ByteOrder::LE),
                 ..Default::default()
@@ -275,6 +280,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: GlobalConfig {
                 default_byte_order: Some(ByteOrder::LE),
                 ..Default::default()
@@ -290,6 +296,7 @@ mod tests {
         assert_eq!(start_mir, end_mir);
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -303,6 +310,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -316,6 +324,7 @@ mod tests {
         assert_eq!(start_mir, end_mir);
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -330,6 +339,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -347,6 +357,7 @@ mod tests {
     #[test]
     fn incorrect_sizes() {
         let mut start_mir = Device {
+            name: None,
             global_config: GlobalConfig {
                 default_byte_order: Some(ByteOrder::LE),
                 ..Default::default()
@@ -365,6 +376,7 @@ mod tests {
         );
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -381,6 +393,7 @@ mod tests {
         );
 
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -401,6 +414,7 @@ mod tests {
     #[test]
     fn wrong_num_bytes_arry() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -420,6 +434,7 @@ mod tests {
     #[test]
     fn int_msb0_parsed_correct() {
         let mut start_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -433,6 +448,7 @@ mod tests {
         run_pass(&mut start_mir).unwrap();
 
         let end_mir = Device {
+            name: None,
             global_config: Default::default(),
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),


### PR DESCRIPTION
Step 1 from #81 

This adds support for generating KDL from MIR.
This provides an easy upgrade path later.
For a window the current inputs and KDL should coexist before the current input methods are abolished.

The CLI can now choose its output.
```
cargo run -- --manifest generation\tests\test-device.yaml --device-name MyTestDevice -g kdl
```