### PR TITLE
Allow uppercase after a number in PascalCase check

### DIFF
--- a/generation/src/mir/lir_transform.rs
+++ b/generation/src/mir/lir_transform.rs
@@ -14,7 +14,7 @@ use super::{
 
 pub fn transform(device: mir::Device, driver_name: &str) -> anyhow::Result<lir::Device> {
     let lenient_pascal_converter = convert_case::Converter::new()
-        .set_boundaries(&convert_case::Boundary::list_from("aA:AAa:_:-: :a1:A1"))
+        .set_boundaries(&convert_case::Boundary::list_from("aA:AAa:_:-: :a1:A1:1A"))
         .set_pattern(convert_case::Pattern::Capital);
     let converted_driver_name = lenient_pascal_converter.convert(driver_name);
 


### PR DESCRIPTION
Adds support for device names that have an uppercase after a number. 

Currently the following code won't compile with the following error: 
`The device name must be given in PascalCase, e.g. "Rtl8139device"`. 

Rust allows the struct name `Rtl8139Interface`, so I modified the PascalCase check to also allow names such as `Rtl8139Device`.

```Rust
pub struct Rtl8139Interface {
    base: u16,
}

device_driver::create_device!(
    device_name: Rtl8139Device,
    ...
)   
```

With this change the above example will compile.