### PR TITLE
Create a bitorder mir pass to centralize setting the default from global config

### DIFF
--- a/generation/src/dsl_hir/mir_transform.rs
+++ b/generation/src/dsl_hir/mir_transform.rs
@@ -346,8 +346,7 @@ fn transform_register(
                 .find_map(|i| match i {
                     dsl_hir::RegisterItem::BitOrder(bi) => Some((*bi).into()),
                     _ => None,
-                })
-                .unwrap_or(global_config.default_bit_order),
+                }),
             allow_bit_overlap: register
                 .register_item_list
                 .register_items
@@ -457,8 +456,7 @@ fn transform_command(
                         dsl_hir::CommandItem::BitOrder(order) => Some((*order).into()),
                         _ => None,
                     }),
-                }
-                .unwrap_or(global_config.default_bit_order),
+                },
                 allow_bit_overlap: match &command_value {
                     dsl_hir::CommandValue::Basic(_) => None,
                     dsl_hir::CommandValue::Extended {
@@ -513,8 +511,7 @@ fn transform_command(
                         dsl_hir::CommandItem::BitOrder(order) => Some((*order).into()),
                         _ => None,
                     }),
-                }
-                .unwrap_or(global_config.default_bit_order),
+                },
                 allow_bit_overlap: match &command_value {
                     dsl_hir::CommandValue::Basic(_) => None,
                     dsl_hir::CommandValue::Extended {
@@ -1277,7 +1274,7 @@ mod tests {
                 address: 10,
                 field_set_in: Some(mir::FieldSet {
                     byte_order: Some(mir::ByteOrder::BE),
-                    bit_order: mir::BitOrder::LSB0,
+                    bit_order: Some(mir::BitOrder::LSB0),
                     fields: vec![mir::Field {
                         cfg_attr: mir::Cfg::new(None),
                         description: Default::default(),
@@ -2178,7 +2175,7 @@ mod tests {
                 field_set: mir::FieldSet {
                     size_bits: 16,
                     byte_order: Some(mir::ByteOrder::LE),
-                    bit_order: mir::BitOrder::MSB0,
+                    bit_order: Some(mir::BitOrder::MSB0),
                     fields: vec![mir::Field {
                         cfg_attr: Default::default(),
                         description: Default::default(),

--- a/generation/src/kdl.rs
+++ b/generation/src/kdl.rs
@@ -821,7 +821,7 @@ fn transform_field_set(
         match bit_order.value() {
             KdlValue::String(s) => match s.parse() {
                 Ok(bit_order) => {
-                    field_set.bit_order = bit_order;
+                    field_set.bit_order = Some(bit_order);
                 }
                 Err(_) => {
                     diagnostics.add(errors::UnexpectedValue {

--- a/generation/src/manifest/mod.rs
+++ b/generation/src/manifest/mod.rs
@@ -276,7 +276,7 @@ fn transform_register(name: &str, map: &impl Map) -> anyhow::Result<mir::Registe
             }
             "bit_order" => {
                 register.field_set.bit_order =
-                    transform_bit_order(value).context("Parsing error for `bit_order`")?;
+                    Some(transform_bit_order(value).context("Parsing error for `bit_order`")?);
             }
             "address" => {
                 register.address = value
@@ -382,8 +382,8 @@ fn transform_command(name: &str, map: &impl Map) -> anyhow::Result<mir::Command>
                 let bit_order =
                     transform_bit_order(value).context("Parsing error for `bit_order`")?;
 
-                field_set_in.bit_order = bit_order;
-                field_set_out.bit_order = bit_order;
+                field_set_in.bit_order = Some(bit_order);
+                field_set_out.bit_order = Some(bit_order);
             }
             "address" => {
                 command.address = value
@@ -1134,7 +1134,7 @@ mod tests {
                 field_set: mir::FieldSet {
                     size_bits: 8,
                     allow_bit_overlap: true,
-                    bit_order: mir::BitOrder::MSB0,
+                    bit_order: Some(mir::BitOrder::MSB0),
                     byte_order: Some(ByteOrder::BE),
                     ..Default::default()
                 },

--- a/generation/src/mir/kdl_transform.rs
+++ b/generation/src/mir/kdl_transform.rs
@@ -438,8 +438,8 @@ fn transform_field_set(name: &str, field_set: &FieldSet, global_config: &GlobalC
         node.push(("byte-order", byte_order.to_string()));
     }
 
-    if field_set.bit_order != global_config.default_bit_order {
-        node.push(("bit-order", field_set.bit_order.to_string()));
+    if let Some(bit_order) = field_set.bit_order {
+        node.push(("bit-order", bit_order.to_string()));
     }
 
     if field_set.allow_bit_overlap {

--- a/generation/src/mir/lir_transform.rs
+++ b/generation/src/mir/lir_transform.rs
@@ -445,7 +445,9 @@ fn transform_field_set<'a>(
         description: description.into(),
         name: field_set_name.to_string(),
         byte_order: field_set.byte_order.unwrap(),
-        bit_order: field_set.bit_order,
+        bit_order: field_set
+            .bit_order
+            .expect("Bitorder should never be none at this point after the MIR passes"),
         size_bits: field_set.size_bits,
         reset_value: reset_value
             .unwrap_or_else(|| vec![0; field_set.size_bits.div_ceil(8) as usize]),

--- a/generation/src/mir/mod.rs
+++ b/generation/src/mir/mod.rs
@@ -354,7 +354,7 @@ pub struct Register {
 pub struct FieldSet {
     pub size_bits: u32,
     pub byte_order: Option<ByteOrder>,
-    pub bit_order: BitOrder,
+    pub bit_order: Option<BitOrder>,
     pub allow_bit_overlap: bool,
     pub fields: Vec<Field>,
 }

--- a/generation/src/mir/passes/bit_order_specified.rs
+++ b/generation/src/mir/passes/bit_order_specified.rs
@@ -1,0 +1,15 @@
+use crate::mir::Device;
+
+use super::recurse_objects_mut;
+
+/// Set the unset bit orders to the global config value
+pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
+    recurse_objects_mut(&mut device.objects, &mut |object| {
+        object.field_sets_mut().for_each(|fs| {
+            if fs.bit_order.is_none() {
+                fs.bit_order = Some(device.global_config.default_bit_order)
+            }
+        });
+        Ok(())
+    })
+}

--- a/generation/src/mir/passes/mod.rs
+++ b/generation/src/mir/passes/mod.rs
@@ -3,6 +3,7 @@ use super::{Device, Object, Repeat};
 mod address_types_big_enough;
 mod address_types_specified;
 mod base_types_specified;
+mod bit_order_specified;
 mod bit_ranges_validated;
 mod bool_fields_checked;
 mod byte_order_specified;
@@ -15,6 +16,7 @@ mod refs_validated;
 mod reset_values_converted;
 
 pub fn run_passes(device: &mut Device) -> anyhow::Result<()> {
+    bit_order_specified::run_pass(device)?;
     device_name_is_pascal::run_pass(device)?;
     propagate_cfg::run_pass(device)?;
     names_normalized::run_pass(device)?;

--- a/generation/src/mir/passes/reset_values_converted.rs
+++ b/generation/src/mir/passes/reset_values_converted.rs
@@ -31,7 +31,9 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
                 Some(reset_value) => {
                     let new_reset_value = convert_reset_value(
                         reset_value.clone(),
-                        reg.field_set.bit_order,
+                        reg.field_set
+                            .bit_order
+                            .expect("Bitorder should be set at this point"),
                         reg.field_set.size_bits,
                         "register",
                         &reg.name,
@@ -64,7 +66,10 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
 
                 let new_reset_value = convert_reset_value(
                     reset_value.clone(),
-                    base_reg.field_set.bit_order,
+                    base_reg
+                        .field_set
+                        .bit_order
+                        .expect("Bitorder should be set at this point"),
                     base_reg.field_set.size_bits,
                     "ref register",
                     name,
@@ -220,6 +225,7 @@ mod tests {
                 reset_value: Some(ResetValue::Integer(0x1F)),
                 field_set: FieldSet {
                     size_bits: 5,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -236,6 +242,7 @@ mod tests {
                 reset_value: Some(ResetValue::Array(vec![0x1F])),
                 field_set: FieldSet {
                     size_bits: 5,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -252,6 +259,7 @@ mod tests {
                 reset_value: Some(ResetValue::Array(vec![0x1F])),
                 field_set: FieldSet {
                     size_bits: 5,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -268,6 +276,7 @@ mod tests {
                 reset_value: Some(ResetValue::Array(vec![0x1F])),
                 field_set: FieldSet {
                     size_bits: 5,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -287,6 +296,7 @@ mod tests {
                 reset_value: Some(ResetValue::Integer(0x423)),
                 field_set: FieldSet {
                     size_bits: 11,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -306,6 +316,7 @@ mod tests {
                 reset_value: Some(ResetValue::Array(vec![0x23, 0x04])),
                 field_set: FieldSet {
                     size_bits: 11,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -323,6 +334,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 11,
                     byte_order: Some(ByteOrder::BE),
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -340,6 +352,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 11,
                     byte_order: Some(ByteOrder::BE),
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -357,7 +370,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 11,
                     byte_order: Some(ByteOrder::BE),
-                    bit_order: BitOrder::MSB0,
+                    bit_order: Some(BitOrder::MSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -375,7 +388,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 11,
                     byte_order: Some(ByteOrder::BE),
-                    bit_order: BitOrder::MSB0,
+                    bit_order: Some(BitOrder::MSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -398,6 +411,7 @@ mod tests {
                 reset_value: Some(ResetValue::Integer(0x423)),
                 field_set: FieldSet {
                     size_bits: 10,
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -418,6 +432,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 10,
                     byte_order: Some(ByteOrder::BE),
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -438,7 +453,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 10,
                     byte_order: Some(ByteOrder::BE),
-                    bit_order: BitOrder::MSB0,
+                    bit_order: Some(BitOrder::MSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -462,6 +477,7 @@ mod tests {
                 field_set: FieldSet {
                     size_bits: 32,
                     byte_order: Some(ByteOrder::LE),
+                    bit_order: Some(BitOrder::LSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -484,7 +500,7 @@ mod tests {
                 reset_value: Some(ResetValue::Integer(0xF8)),
                 field_set: FieldSet {
                     size_bits: 5,
-                    bit_order: BitOrder::MSB0,
+                    bit_order: Some(BitOrder::MSB0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -501,7 +517,7 @@ mod tests {
                 reset_value: Some(ResetValue::Array(vec![0xF8])),
                 field_set: FieldSet {
                     size_bits: 5,
-                    bit_order: BitOrder::MSB0,
+                    bit_order: Some(BitOrder::MSB0),
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
This makes sure it's always set properly