### PR TITLE
Add name and cfg to mir fieldsets

### DIFF
--- a/generation/src/dsl_hir/mir_transform.rs
+++ b/generation/src/dsl_hir/mir_transform.rs
@@ -313,6 +313,9 @@ fn transform_register(
             })
             .transpose()?,
         field_set: mir::FieldSet {
+            cfg_attr: get_cfg_attr(&register.attribute_list)?,
+            description: "".into(),
+            name: register.identifier.to_string(),
             size_bits: register
                 .register_item_list
                 .register_items
@@ -429,6 +432,9 @@ fn transform_command(
                 in_field_list: Some(in_field_list),
                 ..
             } => Some(mir::FieldSet {
+                cfg_attr: get_cfg_attr(&command.attribute_list)?,
+                description: "".into(),
+                name: format!("{}FieldsIn", command.identifier),
                 size_bits: match &command_value {
                     dsl_hir::CommandValue::Basic(_) => None,
                     dsl_hir::CommandValue::Extended {
@@ -484,6 +490,9 @@ fn transform_command(
                 out_field_list: Some(out_field_list),
                 ..
             } => Some(mir::FieldSet {
+                cfg_attr: get_cfg_attr(&command.attribute_list)?,
+                description: "".into(),
+                name: format!("{}FieldsOut", command.identifier),
                 size_bits: match &command_value {
                     dsl_hir::CommandValue::Basic(_) => None,
                     dsl_hir::CommandValue::Extended {
@@ -1151,6 +1160,7 @@ mod tests {
                     stride: 16
                 }),
                 field_set_in: Some(mir::FieldSet {
+                    name: "BarFieldsIn".into(),
                     size_bits: 32,
                     fields: vec![
                         mir::Field {
@@ -1178,6 +1188,7 @@ mod tests {
                     ..Default::default()
                 }),
                 field_set_out: Some(mir::FieldSet {
+                    name: "BarFieldsOut".into(),
                     size_bits: 16,
                     fields: vec![mir::Field {
                         cfg_attr: mir::Cfg::new(None),
@@ -1273,6 +1284,7 @@ mod tests {
                 name: "Bar".into(),
                 address: 10,
                 field_set_in: Some(mir::FieldSet {
+                    name: "BarFieldsIn".into(),
                     byte_order: Some(mir::ByteOrder::BE),
                     bit_order: Some(mir::BitOrder::LSB0),
                     fields: vec![mir::Field {
@@ -2130,6 +2142,7 @@ mod tests {
                 name: "Foo".into(),
                 address: 5,
                 field_set: mir::FieldSet {
+                    name: "Foo".into(),
                     size_bits: 16,
                     ..Default::default()
                 },
@@ -2173,6 +2186,7 @@ mod tests {
                     stride: 120
                 }),
                 field_set: mir::FieldSet {
+                    name: "Foo".into(),
                     size_bits: 16,
                     byte_order: Some(mir::ByteOrder::LE),
                     bit_order: Some(mir::BitOrder::MSB0),
@@ -2229,6 +2243,7 @@ mod tests {
                 address: 5,
                 reset_value: Some(mir::ResetValue::Array(vec![12, 34])),
                 field_set: mir::FieldSet {
+                    name: "Foo".into(),
                     size_bits: 16,
                     ..Default::default()
                 },
@@ -2257,6 +2272,7 @@ mod tests {
                 address: 5,
                 allow_address_overlap: true,
                 field_set: mir::FieldSet {
+                    name: "Foo".into(),
                     size_bits: 16,
                     allow_bit_overlap: true,
                     ..Default::default()

--- a/generation/src/kdl.rs
+++ b/generation/src/kdl.rs
@@ -313,8 +313,13 @@ fn transform_register(
                     continue;
                 }
 
-                field_set = transform_field_set(child, source_code.clone(), diagnostics)
-                    .map(|val| (val, child.name().span()));
+                field_set = transform_field_set(
+                    child,
+                    source_code.clone(),
+                    diagnostics,
+                    name.as_ref().cloned().unwrap_or_default(),
+                )
+                .map(|val| (val, child.name().span()));
             }
             Err(()) => {
                 diagnostics.add(errors::UnexpectedNode {
@@ -448,8 +453,13 @@ fn transform_command(
                     continue;
                 }
 
-                field_set_in = transform_field_set(child, source_code.clone(), diagnostics)
-                    .map(|val| (val, child.name().span()));
+                field_set_in = transform_field_set(
+                    child,
+                    source_code.clone(),
+                    diagnostics,
+                    format!("{}FieldsIn", name.as_deref().unwrap_or_default()),
+                )
+                .map(|val| (val, child.name().span()));
             }
             Ok(CommandField::FieldSetOut) => {
                 if let Some((_, span)) = field_set_out {
@@ -461,8 +471,13 @@ fn transform_command(
                     continue;
                 }
 
-                field_set_out = transform_field_set(child, source_code.clone(), diagnostics)
-                    .map(|val| (val, child.name().span()));
+                field_set_out = transform_field_set(
+                    child,
+                    source_code.clone(),
+                    diagnostics,
+                    format!("{}FieldsOut", name.as_deref().unwrap_or_default()),
+                )
+                .map(|val| (val, child.name().span()));
             }
             Err(()) => {
                 diagnostics.add(errors::UnexpectedNode {
@@ -673,8 +688,12 @@ fn transform_field_set(
     node: &KdlNode,
     source_code: NamedSourceCode,
     diagnostics: &mut Diagnostics,
+    default_name: String,
 ) -> Option<FieldSet> {
-    let mut field_set = FieldSet::default();
+    let mut field_set = FieldSet {
+        name: default_name,
+        ..Default::default()
+    };
 
     let mut unexpected_entries = errors::UnexpectedEntries {
         source_code: source_code.clone(),

--- a/generation/src/kdl.rs
+++ b/generation/src/kdl.rs
@@ -691,7 +691,11 @@ fn transform_field_set(
     default_name: String,
 ) -> Option<FieldSet> {
     let mut field_set = FieldSet {
-        name: default_name,
+        name: node
+            .ty()
+            .map(|ty| ty.value().into())
+            .unwrap_or(default_name),
+        description: parse_description(node),
         ..Default::default()
     };
 
@@ -1398,8 +1402,8 @@ fn parse_description(node: &KdlNode) -> String {
         format
             .leading
             .lines()
-            .filter(|line| line.starts_with("///"))
-            .map(|line| line.trim_start_matches("///").trim())
+            .filter(|line| line.trim_start().starts_with("///"))
+            .map(|line| line.trim().trim_start_matches("///"))
             .join("\n")
     } else {
         Default::default()

--- a/generation/src/lir/code_transform.rs
+++ b/generation/src/lir/code_transform.rs
@@ -19,7 +19,7 @@ impl<'a> DeviceTemplateRust<'a> {
 fn description_to_docstring(description: &str) -> String {
     description
         .lines()
-        .map(|line| format!("/// {line}"))
+        .map(|line| format!("///{}{line}", if line.starts_with(' ') { "" } else { " " }))
         .join("\n")
 }
 

--- a/generation/src/mir/mod.rs
+++ b/generation/src/mir/mod.rs
@@ -352,6 +352,9 @@ pub struct Register {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FieldSet {
+    pub cfg_attr: Cfg,
+    pub description: String,
+    pub name: String,
     pub size_bits: u32,
     pub byte_order: Option<ByteOrder>,
     pub bit_order: Option<BitOrder>,
@@ -683,6 +686,18 @@ pub trait Unique {
     fn id(&self) -> UniqueId;
 }
 
+impl Unique for Device {
+    fn id(&self) -> UniqueId {
+        UniqueId {
+            object_name: self
+                .name
+                .clone()
+                .expect("Can only get a device unique id when it's initialized with a name"),
+            object_cfg: Cfg::default(),
+        }
+    }
+}
+
 macro_rules! impl_unique {
     ($t:ty) => {
         impl Unique for $t {
@@ -703,6 +718,7 @@ impl_unique!(RefObject);
 impl_unique!(Block);
 impl_unique!(Enum);
 impl_unique!(EnumVariant);
+impl_unique!(FieldSet);
 
 impl Unique for Object {
     fn id(&self) -> UniqueId {

--- a/generation/src/mir/passes/field_set_descriptions_set.rs
+++ b/generation/src/mir/passes/field_set_descriptions_set.rs
@@ -1,0 +1,19 @@
+use crate::mir::Device;
+
+use super::recurse_objects_mut;
+
+/// For any (inline) fieldset that doesn't have a description, use the description of the parent object
+pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
+    recurse_objects_mut(&mut device.objects, &mut |object| {
+        if !object.description().is_empty() {
+            let description = object.description().to_owned();
+
+            object.field_sets_mut().for_each(|fs| {
+                if fs.description.is_empty() {
+                    fs.description = description.clone();
+                }
+            });
+        }
+        Ok(())
+    })
+}

--- a/generation/src/mir/passes/mod.rs
+++ b/generation/src/mir/passes/mod.rs
@@ -9,6 +9,7 @@ mod bool_fields_checked;
 mod byte_order_specified;
 mod device_name_is_pascal;
 mod enum_values_checked;
+mod field_set_descriptions_set;
 mod names_normalized;
 mod names_unique;
 mod propagate_cfg;
@@ -30,6 +31,7 @@ pub fn run_passes(device: &mut Device) -> anyhow::Result<()> {
     refs_validated::run_pass(device)?;
     address_types_specified::run_pass(device)?;
     address_types_big_enough::run_pass(device)?;
+    field_set_descriptions_set::run_pass(device)?;
 
     Ok(())
 }

--- a/generation/src/mir/passes/names_unique.rs
+++ b/generation/src/mir/passes/names_unique.rs
@@ -10,6 +10,8 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
     let mut seen_object_ids = HashSet::new();
     let mut generated_type_ids = HashSet::new();
 
+    generated_type_ids.insert(device.id());
+
     recurse_objects_mut(&mut device.objects, &mut |object| {
         anyhow::ensure!(
             seen_object_ids.insert(object.id()),
@@ -18,6 +20,16 @@ pub fn run_pass(device: &mut Device) -> anyhow::Result<()> {
         );
 
         for field_set in object.field_sets() {
+            // The object and its fieldset may have the same name.
+            // If they have, the uniqueness is already checked.
+            // If not, it's checked here
+            anyhow::ensure!(
+                object.name() == field_set.name || seen_object_ids.insert(field_set.id()),
+                "Duplicate fieldset name found in object `{}`: `{}`",
+                object.name(),
+                field_set.name
+            );
+
             let mut seen_field_names = HashSet::new();
             for field in &field_set.fields {
                 anyhow::ensure!(
@@ -77,7 +89,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
-            name: None,
+            name: Some("Device".into()),
             global_config,
             objects: vec![
                 Object::Buffer(Buffer {
@@ -103,7 +115,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
-            name: None,
+            name: Some("Device".into()),
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -138,7 +150,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
-            name: None,
+            name: Some("Device".into()),
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -189,7 +201,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
-            name: None,
+            name: Some("Device".into()),
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),
@@ -232,7 +244,7 @@ mod tests {
         };
 
         let mut start_mir = Device {
-            name: None,
+            name: Some("Device".into()),
             global_config,
             objects: vec![Object::Register(Register {
                 name: "Reg".into(),

--- a/tests/cases/device_definition_errors/device_definition_errors.rs
+++ b/tests/cases/device_definition_errors/device_definition_errors.rs
@@ -759,15 +759,29 @@ pub mod foo_d_6 {
             )
         }
     
+        /// Hello!
+    
         pub fn foor_8(
             &mut self,
-        ) -> ::device_driver::RegisterOperation<'_, I, u8, field_sets::Foor8, ::device_driver::RW> {
+        ) -> ::device_driver::RegisterOperation<
+            '_,
+            I,
+            u8,
+            field_sets::CustomFieldSetName,
+            ::device_driver::RW,
+        > {
             let address = self.base_address + 4;
     
-            ::device_driver::RegisterOperation::<'_, I, u8, field_sets::Foor8, ::device_driver::RW>::new(
+            ::device_driver::RegisterOperation::<
+                '_,
+                I,
+                u8,
+                field_sets::CustomFieldSetName,
+                ::device_driver::RW,
+            >::new(
                 self.interface(),
                 address as u8,
-                field_sets::Foor8::new,
+                field_sets::CustomFieldSetName::new,
             )
         }
     
@@ -836,6 +850,8 @@ pub mod foo_d_6 {
             )
         }
     
+        /// This is a block
+    
         pub fn b_1(&mut self) -> B1<'_, I> {
             let address = self.base_address + 5;
     
@@ -854,6 +870,8 @@ pub mod foo_d_6 {
             B2::<'_, I>::new(self.interface(), address)
         }
     }
+    
+    /// This is a block
     
     #[derive(Debug)]
     pub struct B1<'i, I> {
@@ -1449,13 +1467,15 @@ pub mod foo_d_6 {
             }
         }
     
+        /// This fieldset has a custom name
+    
         #[derive(Copy, Clone, Eq, PartialEq)]
-        pub struct Foor8 {
+        pub struct CustomFieldSetName {
             /// The internal bits
             bits: [u8; 1],
         }
     
-        impl ::device_driver::FieldSet for Foor8 {
+        impl ::device_driver::FieldSet for CustomFieldSetName {
             const SIZE_BITS: u32 = 8;
             fn new_with_zero() -> Self {
                 Self::new_zero()
@@ -1468,7 +1488,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl Foor8 {
+        impl CustomFieldSetName {
             /// Create a new instance, loaded with the reset value (if any)
             pub const fn new() -> Self {
                 Self { bits: [0] }
@@ -1533,21 +1553,21 @@ pub mod foo_d_6 {
             }
         }
     
-        impl From<[u8; 1]> for Foor8 {
+        impl From<[u8; 1]> for CustomFieldSetName {
             fn from(bits: [u8; 1]) -> Self {
                 Self { bits }
             }
         }
     
-        impl From<Foor8> for [u8; 1] {
-            fn from(val: Foor8) -> Self {
+        impl From<CustomFieldSetName> for [u8; 1] {
+            fn from(val: CustomFieldSetName) -> Self {
                 val.bits
             }
         }
     
-        impl core::fmt::Debug for Foor8 {
+        impl core::fmt::Debug for CustomFieldSetName {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-                let mut d = f.debug_struct("Foor8");
+                let mut d = f.debug_struct("CustomFieldSetName");
     
                 d.field("bar", &self.bar());
     
@@ -1557,7 +1577,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitAnd for Foor8 {
+        impl core::ops::BitAnd for CustomFieldSetName {
             type Output = Self;
             fn bitand(mut self, rhs: Self) -> Self::Output {
                 self &= rhs;
@@ -1565,7 +1585,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitAndAssign for Foor8 {
+        impl core::ops::BitAndAssign for CustomFieldSetName {
             fn bitand_assign(&mut self, rhs: Self) {
                 for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
                     *l &= *r;
@@ -1573,7 +1593,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitOr for Foor8 {
+        impl core::ops::BitOr for CustomFieldSetName {
             type Output = Self;
             fn bitor(mut self, rhs: Self) -> Self::Output {
                 self |= rhs;
@@ -1581,7 +1601,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitOrAssign for Foor8 {
+        impl core::ops::BitOrAssign for CustomFieldSetName {
             fn bitor_assign(&mut self, rhs: Self) {
                 for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
                     *l |= *r;
@@ -1589,7 +1609,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitXor for Foor8 {
+        impl core::ops::BitXor for CustomFieldSetName {
             type Output = Self;
             fn bitxor(mut self, rhs: Self) -> Self::Output {
                 self ^= rhs;
@@ -1597,7 +1617,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::BitXorAssign for Foor8 {
+        impl core::ops::BitXorAssign for CustomFieldSetName {
             fn bitxor_assign(&mut self, rhs: Self) {
                 for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
                     *l ^= *r;
@@ -1605,7 +1625,7 @@ pub mod foo_d_6 {
             }
         }
     
-        impl core::ops::Not for Foor8 {
+        impl core::ops::Not for CustomFieldSetName {
             type Output = Self;
             fn not(mut self) -> Self::Output {
                 for val in self.bits.iter_mut() {
@@ -2320,7 +2340,8 @@ pub mod foo_d_6 {
     
             Foor7(Foor7),
     
-            Foor8(Foor8),
+            /// This fieldset has a custom name
+            CustomFieldSetName(CustomFieldSetName),
     
             Foor9(Foor9),
     
@@ -2341,7 +2362,7 @@ pub mod foo_d_6 {
     
                     Self::Foor7(val) => core::fmt::Debug::fmt(val, _f),
     
-                    Self::Foor8(val) => core::fmt::Debug::fmt(val, _f),
+                    Self::CustomFieldSetName(val) => core::fmt::Debug::fmt(val, _f),
     
                     Self::Foor9(val) => core::fmt::Debug::fmt(val, _f),
     
@@ -2381,9 +2402,9 @@ pub mod foo_d_6 {
             }
         }
     
-        impl From<Foor8> for FieldSetValue {
-            fn from(val: Foor8) -> Self {
-                Self::Foor8(val)
+        impl From<CustomFieldSetName> for FieldSetValue {
+            fn from(val: CustomFieldSetName) -> Self {
+                Self::CustomFieldSetName(val)
             }
         }
     

--- a/tests/cases/device_definition_errors/diagnostics.kdl.txt
+++ b/tests/cases/device_definition_errors/diagnostics.kdl.txt
@@ -406,307 +406,307 @@
     ╰────
 
   error: Duplicate entry
-    ╭─[cases/device_definition_errors/input.kdl:95:20]
- 94 │         fields size-bits=8 {
- 95 │             bar RW RO
+    ╭─[cases/device_definition_errors/input.kdl:96:20]
+ 95 │         (CustomFieldSetName)fields size-bits=8 {
+ 96 │             bar RW RO
     ·                 ─┬ ─┬
     ·                  │  ╰── The duplicate entry
     ·                  ╰── The original entry
- 96 │             bar @a @-1:8 @3 @3:0
+ 97 │             bar @a @-1:8 @3 @3:0
     ╰────
   help: This type of entry can only appear once. Try removing one of the entries
 
   error: Missing entry
-    ╭─[cases/device_definition_errors/input.kdl:95:13]
- 94 │         fields size-bits=8 {
- 95 │             bar RW RO
+    ╭─[cases/device_definition_errors/input.kdl:96:13]
+ 95 │         (CustomFieldSetName)fields size-bits=8 {
+ 96 │             bar RW RO
     ·             ─┬─
     ·              ╰── This node should have one or more of these entries: `address ("@<u32>:<u32>")`
- 96 │             bar @a @-1:8 @3 @3:0
+ 97 │             bar @a @-1:8 @3 @3:0
     ╰────
   help: Check the book for all the requirements
 
   error: Bad format
-    ╭─[cases/device_definition_errors/input.kdl:96:17]
- 95 │             bar RW RO
- 96 │             bar @a @-1:8 @3 @3:0
+    ╭─[cases/device_definition_errors/input.kdl:97:17]
+ 96 │             bar RW RO
+ 97 │             bar @a @-1:8 @3 @3:0
     ·                 ─┬
     ·                  ╰── Value could not be parsed correctly. Use the following format: `@<u32>`
- 97 │             baz @7:4 blah
+ 98 │             baz @7:4 blah
     ╰────
   help: An example: `@10`
 
   error: Bad format
-    ╭─[cases/device_definition_errors/input.kdl:96:20]
- 95 │             bar RW RO
- 96 │             bar @a @-1:8 @3 @3:0
+    ╭─[cases/device_definition_errors/input.kdl:97:20]
+ 96 │             bar RW RO
+ 97 │             bar @a @-1:8 @3 @3:0
     ·                    ──┬──
     ·                      ╰── Value could not be parsed correctly. Use the following format: `@<u32>:<u32>`
- 97 │             baz @7:4 blah
+ 98 │             baz @7:4 blah
     ╰────
   help: An example: `@7:0`
 
   error: Duplicate entry
-    ╭─[cases/device_definition_errors/input.kdl:96:29]
- 95 │             bar RW RO
- 96 │             bar @a @-1:8 @3 @3:0
+    ╭─[cases/device_definition_errors/input.kdl:97:29]
+ 96 │             bar RW RO
+ 97 │             bar @a @-1:8 @3 @3:0
     ·                          ─┬ ──┬─
     ·                           │   ╰── The duplicate entry
     ·                           ╰── The original entry
- 97 │             baz @7:4 blah
+ 98 │             baz @7:4 blah
     ╰────
   help: This type of entry can only appear once. Try removing one of the entries
 
   error: Unexpected value
-    ╭─[cases/device_definition_errors/input.kdl:97:22]
- 96 │             bar @a @-1:8 @3 @3:0
- 97 │             baz @7:4 blah
+    ╭─[cases/device_definition_errors/input.kdl:98:22]
+ 97 │             bar @a @-1:8 @3 @3:0
+ 98 │             baz @7:4 blah
     ·                      ──┬─
     ·                        ╰── Expected one of these values: `@<u32>`, `@<u32>:<u32>`, `RW`, `RO`, `WO`
- 98 │         }
+ 99 │         }
     ╰────
 
   error: Unexpected value
-     ╭─[cases/device_definition_errors/input.kdl:105:14]
- 104 │             (uint)baz @2:1
- 105 │             (i16a)quux @4:3
+     ╭─[cases/device_definition_errors/input.kdl:106:14]
+ 105 │             (uint)baz @2:1
+ 106 │             (i16a)quux @4:3
      ·              ──┬─
      ·                ╰── Expected one of these values: `bool`, `uint`, `int`, `u8`, `u16`, `u32`, `i8`, `i16`, `i32`, `i64`, `u64`, `<base>:<target>`, `<base>:<target>?`
- 106 │             (:MyCustomType?)qus @6:5
+ 107 │             (:MyCustomType?)qus @6:5
      ╰────
 
   error: Inline enum definition without name
-     ╭─[cases/device_definition_errors/input.kdl:118:13]
- 117 │             }
- 118 │             baz @3:2 {
+     ╭─[cases/device_definition_errors/input.kdl:119:13]
+ 118 │             }
+ 119 │             baz @3:2 {
      ·             ─┬─
      ·              ╰── Add conversion type specification to this field
- 119 │ 
+ 120 │ 
      ╰────
   help: An inline enum definition is only possible when a conversion is specified, for example: `(uint:EnumName)`
 
   error: Inline enum definition without name
-     ╭─[cases/device_definition_errors/input.kdl:121:14]
- 120 │             }
- 121 │             (uint)bam @5:4 {
+     ╭─[cases/device_definition_errors/input.kdl:122:14]
+ 121 │             }
+ 122 │             (uint)bam @5:4 {
      ·              ──┬─ ─┬─
      ·                │   ╰── Add conversion type specification to this field
      ·                ╰── A type specifier already exists, but misses the conversion
- 122 │ 
+ 123 │ 
      ╰────
   help: An inline enum definition is only possible when a conversion is specified, for example: `(uint:EnumName)`
 
   error: Unexpected value
-     ╭─[cases/device_definition_errors/input.kdl:126:19]
- 125 │                 A
- 126 │                 B 1.0
+     ╭─[cases/device_definition_errors/input.kdl:127:19]
+ 126 │                 A
+ 127 │                 B 1.0
      ·                   ─┬─
      ·                    ╰── Expected one of these values: ``, `<integer>`, `default`, `catch-all`
- 127 │                 C default-value
+ 128 │                 C default-value
      ╰────
 
   error: Unexpected value
-     ╭─[cases/device_definition_errors/input.kdl:127:19]
- 126 │                 B 1.0
- 127 │                 C default-value
+     ╭─[cases/device_definition_errors/input.kdl:128:19]
+ 127 │                 B 1.0
+ 128 │                 C default-value
      ·                   ──────┬──────
      ·                         ╰── Expected one of these values: ``, `<integer>`, `default`, `catch-all`
- 128 │                 D #null 2
+ 129 │                 D #null 2
      ╰────
 
   error: Unexpected entries
-     ╭─[cases/device_definition_errors/input.kdl:128:25]
- 127 │                 C default-value
- 128 │                 D #null 2
+     ╭─[cases/device_definition_errors/input.kdl:129:25]
+ 128 │                 C default-value
+ 129 │                 D #null 2
      ·                         ┬
      ·                         ╰── This entry is unexpected
- 129 │             }
+ 130 │             }
      ╰────
   help: Some entries require a name, require to be anonymous or are expected to be of a certain type. Check the book
         to see the specification
         These entries may also just be superfluous. Try removing them or check other errors to see what's expected
 
   error: Unexpected value
-     ╭─[cases/device_definition_errors/input.kdl:128:19]
- 127 │                 C default-value
- 128 │                 D #null 2
+     ╭─[cases/device_definition_errors/input.kdl:129:19]
+ 128 │                 C default-value
+ 129 │                 D #null 2
      ·                   ──┬──
      ·                     ╰── Expected one of these values: ``, `<integer>`, `default`, `catch-all`
- 129 │             }
+ 130 │             }
      ╰────
 
   error: Missing object name
-     ╭─[cases/device_definition_errors/input.kdl:132:5]
- 131 │     }
- 132 │     command {
+     ╭─[cases/device_definition_errors/input.kdl:133:5]
+ 132 │     }
+ 133 │     command {
      ·     ───┬───
      ·        ╰── For this object
- 133 │ 
+ 134 │ 
      ╰────
   help: The name is specified by the first entry of the node. It must be an anonymous string, e.g. `command Foo { }`
 
   error: Missing child node
-     ╭─[cases/device_definition_errors/input.kdl:132:5]
- 131 │     }
- 132 │     command {
+     ╭─[cases/device_definition_errors/input.kdl:133:5]
+ 132 │     }
+ 133 │     command {
      ·     ───┬───
      ·        ╰── This command is missing the required `address` node
- 133 │ 
+ 134 │ 
      ╰────
   help: Check the book to see all required nodes
 
   error: Missing child node
-     ╭─[cases/device_definition_errors/input.kdl:135:13]
- 134 │     }
- 135 │     command fooc0 {
+     ╭─[cases/device_definition_errors/input.kdl:136:13]
+ 135 │     }
+ 136 │     command fooc0 {
      ·             ──┬──
      ·               ╰── This command is missing the required `address` node
- 136 │ 
+ 137 │ 
      ╰────
   help: Check the book to see all required nodes
 
   error: Missing entry
-     ╭─[cases/device_definition_errors/input.kdl:140:9]
- 139 │         address 0
- 140 │         repeat
+     ╭─[cases/device_definition_errors/input.kdl:141:9]
+ 140 │         address 0
+ 141 │         repeat
      ·         ───┬──
      ·            ╰── This node should have one or more of these entries: `count=<integer>`, `stride=<integer>`
- 141 │         blah
+ 142 │         blah
      ╰────
   help: Check the book for all the requirements
 
   error: Unexpected node
-     ╭─[cases/device_definition_errors/input.kdl:141:9]
- 140 │         repeat
- 141 │         blah
+     ╭─[cases/device_definition_errors/input.kdl:142:9]
+ 141 │         repeat
+ 142 │         blah
      ·         ──┬─
      ·           ╰── The unexpected node
- 142 │         in {
+ 143 │         in {
      ╰────
   help: Expected a node with one of these names: `allow-address-overlap`, `address`, `repeat`, `in`, `out`
 
   error: Missing entry
-     ╭─[cases/device_definition_errors/input.kdl:142:9]
- 141 │         blah
- 142 │         in {
+     ╭─[cases/device_definition_errors/input.kdl:143:9]
+ 142 │         blah
+ 143 │         in {
      ·         ─┬
      ·          ╰── This node should have one or more of these entries: `size-bits`
- 143 │             
+ 144 │             
      ╰────
   help: Check the book for all the requirements
 
   error: Missing object name
-     ╭─[cases/device_definition_errors/input.kdl:149:5]
- 148 │     }
- 149 │     buffer {
+     ╭─[cases/device_definition_errors/input.kdl:150:5]
+ 149 │     }
+ 150 │     buffer {
      ·     ───┬──
      ·        ╰── For this object
- 150 │ 
+ 151 │ 
      ╰────
   help: The name is specified by the first entry of the node. It must be an anonymous string, e.g. `buffer Foo { }`
 
   error: Missing child node
-     ╭─[cases/device_definition_errors/input.kdl:149:5]
- 148 │     }
- 149 │     buffer {
+     ╭─[cases/device_definition_errors/input.kdl:150:5]
+ 149 │     }
+ 150 │     buffer {
      ·     ───┬──
      ·        ╰── This register is missing the required `address` node
- 150 │ 
+ 151 │ 
      ╰────
   help: Check the book to see all required nodes
 
   error: Missing child node
-     ╭─[cases/device_definition_errors/input.kdl:152:12]
- 151 │     }
- 152 │     buffer foob0 {
+     ╭─[cases/device_definition_errors/input.kdl:153:12]
+ 152 │     }
+ 153 │     buffer foob0 {
      ·            ──┬──
      ·              ╰── This register is missing the required `address` node
- 153 │         
+ 154 │         
      ╰────
   help: Check the book to see all required nodes
 
   error: Unexpected node
-     ╭─[cases/device_definition_errors/input.kdl:157:9]
- 156 │         address 0
- 157 │         addressssss 500
+     ╭─[cases/device_definition_errors/input.kdl:158:9]
+ 157 │         address 0
+ 158 │         addressssss 500
      ·         ─────┬─────
      ·              ╰── The unexpected node
- 158 │         address 1
+ 159 │         address 1
      ╰────
   help: Expected a node with one of these names: `access`, `address`
 
   error: Duplicate node
-     ╭─[cases/device_definition_errors/input.kdl:158:9]
- 155 │     buffer foob1 {
- 156 │         address 0
+     ╭─[cases/device_definition_errors/input.kdl:159:9]
+ 156 │     buffer foob1 {
+ 157 │         address 0
      ·         ───┬───
      ·            ╰── The original node
- 157 │         addressssss 500
- 158 │         address 1
+ 158 │         addressssss 500
+ 159 │         address 1
      ·         ───┬───
      ·            ╰── The duplicate node
- 159 │     }
+ 160 │     }
      ╰────
   help: This type of node can only appear once. Try removing one of the nodes
 
   error: Unexpected value
-     ╭─[cases/device_definition_errors/input.kdl:162:16]
- 161 │         address 2
- 162 │         access BLAH
+     ╭─[cases/device_definition_errors/input.kdl:163:16]
+ 162 │         address 2
+ 163 │         access BLAH
      ·                ──┬─
      ·                  ╰── Expected one of these values: `RW`, `RO`, `WO`
- 163 │         access RO
+ 164 │         access RO
      ╰────
 
   error: Missing object name
-     ╭─[cases/device_definition_errors/input.kdl:165:5]
- 164 │     }
- 165 │     block
+     ╭─[cases/device_definition_errors/input.kdl:166:5]
+ 165 │     }
+ 166 │     block
      ·     ──┬──
      ·       ╰── For this object
- 166 │     /// This is a block
+ 167 │     /// This is a block
      ╰────
   help: The name is specified by the first entry of the node. It must be an anonymous string, e.g. `block Foo { }`
 
   error: Unexpected node
-     ╭─[cases/device_definition_errors/input.kdl:168:9]
- 167 │     block b1 {
- 168 │         foo
+     ╭─[cases/device_definition_errors/input.kdl:169:9]
+ 168 │     block b1 {
+ 169 │         foo
      ·         ─┬─
      ·          ╰── The unexpected node
- 169 │         offset d
+ 170 │         offset d
      ╰────
   help: Expected a node with one of these names: `offset`, `repeat`, `block`, `register`, `command`, `buffer`
 
   error: Unexpected type
-     ╭─[cases/device_definition_errors/input.kdl:169:16]
- 168 │         foo
- 169 │         offset d
+     ╭─[cases/device_definition_errors/input.kdl:170:16]
+ 169 │         foo
+ 170 │         offset d
      ·                ┬
      ·                ╰── Unexpected type: expected a integer
- 170 │         offset 5
+ 171 │         offset 5
      ╰────
 
   error: Duplicate node
-     ╭─[cases/device_definition_errors/input.kdl:171:9]
- 169 │         offset d
- 170 │         offset 5
+     ╭─[cases/device_definition_errors/input.kdl:172:9]
+ 170 │         offset d
+ 171 │         offset 5
      ·         ───┬──
      ·            ╰── The original node
- 171 │         offset 20
+ 172 │         offset 20
      ·         ───┬──
      ·            ╰── The duplicate node
- 172 │     }
+ 173 │     }
      ╰────
   help: This type of node can only appear once. Try removing one of the nodes
 
   error: Missing entry
-     ╭─[cases/device_definition_errors/input.kdl:174:9]
- 173 │     block b2 {
- 174 │         repeat
+     ╭─[cases/device_definition_errors/input.kdl:175:9]
+ 174 │     block b2 {
+ 175 │         repeat
      ·         ───┬──
      ·            ╰── This node should have one or more of these entries: `count=<integer>`, `stride=<integer>`
- 175 │         repeat count=2 stride=4
+ 176 │         repeat count=2 stride=4
      ╰────
   help: Check the book for all the requirements
 

--- a/tests/cases/device_definition_errors/input.kdl
+++ b/tests/cases/device_definition_errors/input.kdl
@@ -91,7 +91,8 @@ device FooD6 {
     /// Hello!
     register foor8 {
         address 4
-        fields size-bits=8 {
+        /// This fieldset has a custom name
+        (CustomFieldSetName)fields size-bits=8 {
             bar RW RO
             bar @a @-1:8 @3 @3:0
             baz @7:4 blah

--- a/tests/cases/device_definition_errors/stderr.rs.txt
+++ b/tests/cases/device_definition_errors/stderr.rs.txt
@@ -1,25 +1,25 @@
 error: The device driver input has errors that need to be solved!
-    --> device_definition_errors.rs:2490:1
+    --> device_definition_errors.rs:2511:1
      |
-2490 | compile_error!("The device driver input has errors that need to be solved!");
+2511 | compile_error!("The device driver input has errors that need to be solved!");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0412]: cannot find type `MyCustomType` in module `super`
-    --> device_definition_errors.rs:1685:32
+    --> device_definition_errors.rs:1705:32
      |
-1685 |             ) -> Result<super::MyCustomType, <super::MyCustomType as TryFrom<u8>>::Error> {
+1705 |             ) -> Result<super::MyCustomType, <super::MyCustomType as TryFrom<u8>>::Error> {
      |                                ^^^^^^^^^^^^ not found in `super`
 
 error[E0412]: cannot find type `MyCustomType` in module `super`
-    --> device_definition_errors.rs:1685:54
+    --> device_definition_errors.rs:1705:54
      |
-1685 |             ) -> Result<super::MyCustomType, <super::MyCustomType as TryFrom<u8>>::Error> {
+1705 |             ) -> Result<super::MyCustomType, <super::MyCustomType as TryFrom<u8>>::Error> {
      |                                                      ^^^^^^^^^^^^ not found in `super`
 
 error[E0412]: cannot find type `MyCustomType` in module `super`
-    --> device_definition_errors.rs:1744:53
+    --> device_definition_errors.rs:1764:53
      |
-1744 |             pub fn set_qus(&mut self, value: super::MyCustomType) {
+1764 |             pub fn set_qus(&mut self, value: super::MyCustomType) {
      |                                                     ^^^^^^^^^^^^ not found in `super`
 
 For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
In prep for #77.
This is only really going to be exposed in KDL.
For all other inputs, everything remains status quo.

TODO:
- [x] Use the KDL type specifier for inline field set name
- [x] Parse doc comments on inline fieldsets