### PR TITLE
Make extern only use try_into

### DIFF
--- a/compiler/src/mir/lir_transform.rs
+++ b/compiler/src/mir/lir_transform.rs
@@ -259,7 +259,7 @@ fn transform_field_set<'a>(
                     if fc.use_try {
                         lir::FieldConversionMethod::TryInto(fc.type_name.clone())
                     }
-                    // Are we pointing at a potentially infallible enum and do we fullfil the requirements?
+                    // Are we pointing at a potentially infallible enum and do we fulfil the requirements?
                     else if let Some(mir::Enum {
                         generation_style: Some(mir::EnumGenerationStyle::InfallibleWithinRange),
                         size_bits,

--- a/compiler/src/mir/passes/extern_values_checked.rs
+++ b/compiler/src/mir/passes/extern_values_checked.rs
@@ -38,7 +38,7 @@ pub fn run_pass(device: &mut Device) -> miette::Result<()> {
                         integer.size_bits() >= size_bits.unwrap_or_default(),
                         "Extern `{object_name}` has specified a bit size that is larger than its base type. This is not allowed"
                     );
-                    (Some(integer), size_bits.unwrap_or(integer.size_bits()))
+                    (Some(integer), size_bits.unwrap_or_default())
                 }
             };
 

--- a/compiler/src/mir/passes/field_conversion_valid.rs
+++ b/compiler/src/mir/passes/field_conversion_valid.rs
@@ -73,12 +73,20 @@ pub fn run_pass(device: &mut Device) -> miette::Result<()> {
                                     .size_bits
                                     .expect("Extern size_bits is already set in a previous pass");
 
-                                ensure!(
-                                    field_bits <= extern_bits,
-                                    "Field `{}` of FieldSet `{}` uses an infallible conversion for an extern of {extern_bits} bits. The field is {field_bits} bits large and thus infallible conversion is not possible",
-                                    field.name,
-                                    field_set.name
-                                )
+                                if extern_bits == 0 {
+                                    bail!(
+                                        "Field `{}` of FieldSet `{}` uses an infallible conversion for an extern that doesn't support that",
+                                        field.name,
+                                        field_set.name
+                                    )
+                                } else {
+                                    ensure!(
+                                        field_bits <= extern_bits,
+                                        "Field `{}` of FieldSet `{}` uses an infallible conversion for an extern of {extern_bits} bits. The field is {field_bits} bits large and thus infallible conversion is not possible",
+                                        field.name,
+                                        field_set.name
+                                    );
+                                }
                             }
                         }
                         Some(_) => bail!(

--- a/tests/cases/device_definition_errors/device_definition_errors.rs
+++ b/tests/cases/device_definition_errors/device_definition_errors.rs
@@ -1742,11 +1742,11 @@ pub mod foo_d_6 {
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Fs2 {
         /// The internal bits
-        bits: [u8; 1],
+        bits: [u8; 4],
     }
     
     impl ::device_driver::FieldSet for Fs2 {
-        const SIZE_BITS: u32 = 8;
+        const SIZE_BITS: u32 = 32;
         fn get_inner_buffer(&self) -> &[u8] {
             &self.bits
         }
@@ -1758,7 +1758,7 @@ pub mod foo_d_6 {
     impl Fs2 {
         /// Create a new instance, loaded with all zeroes
         pub const fn new() -> Self {
-            Self { bits: [0; 1] }
+            Self { bits: [0; 4] }
         }
     
         ///Read the `value` field of the register.
@@ -1768,7 +1768,17 @@ pub mod foo_d_6 {
             let raw = unsafe {
                 ::device_driver::ops::load_lsb0::<u8, ::device_driver::ops::LE>(&self.bits, 0, 7)
             };
-            raw.into()
+            unsafe { raw.try_into().unwrap_unchecked() }
+        }
+    
+        ///Read the `value_2` field of the register.
+        ///
+    
+        pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+            let raw = unsafe {
+                ::device_driver::ops::load_lsb0::<u8, ::device_driver::ops::LE>(&self.bits, 7, 11)
+            };
+            raw.try_into()
         }
     
         ///Write the `value` field of the register.
@@ -1786,6 +1796,22 @@ pub mod foo_d_6 {
                 )
             };
         }
+    
+        ///Write the `value_2` field of the register.
+        ///
+    
+        pub fn set_value_2(&mut self, value: Etype3) {
+            let raw = value.into();
+    
+            unsafe {
+                ::device_driver::ops::store_lsb0::<u8, ::device_driver::ops::LE>(
+                    raw,
+                    7,
+                    11,
+                    &mut self.bits,
+                )
+            };
+        }
     }
     
     impl Default for Fs2 {
@@ -1794,13 +1820,13 @@ pub mod foo_d_6 {
         }
     }
     
-    impl From<[u8; 1]> for Fs2 {
-        fn from(bits: [u8; 1]) -> Self {
+    impl From<[u8; 4]> for Fs2 {
+        fn from(bits: [u8; 4]) -> Self {
             Self { bits }
         }
     }
     
-    impl From<Fs2> for [u8; 1] {
+    impl From<Fs2> for [u8; 4] {
         fn from(val: Fs2) -> Self {
             val.bits
         }
@@ -1811,6 +1837,8 @@ pub mod foo_d_6 {
             let mut d = f.debug_struct("Fs2");
     
             d.field("value", &self.value());
+    
+            d.field("value_2", &self.value_2());
     
             d.finish()
         }

--- a/tests/cases/device_definition_errors/input.kdl
+++ b/tests/cases/device_definition_errors/input.kdl
@@ -205,7 +205,9 @@ device FooD6 {
     (abc:something?)extern etype1 a unsafe-size-bits=1
     /// Some docs over here!
     (u8)extern etype2 unsafe-size-bits=7
-    fieldset fs2 size-bits=8 {
+    (u8)extern etype3
+    fieldset fs2 size-bits=32 byte-order=LE {
         (:etype2)value @6:0
+        (:etype3?)value2 @10:7
     }
 }

--- a/tests/cases/device_definition_errors/stderr.rs.txt
+++ b/tests/cases/device_definition_errors/stderr.rs.txt
@@ -1,7 +1,7 @@
 error: The device driver input has errors that need to be solved!
-    --> device_definition_errors.rs:2047:1
+    --> device_definition_errors.rs:2075:1
      |
-2047 | compile_error!("The device driver input has errors that need to be solved!");
+2075 | compile_error!("The device driver input has errors that need to be solved!");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0412]: cannot find type `Etype2` in this scope
@@ -10,11 +10,39 @@ error[E0412]: cannot find type `Etype2` in this scope
 1767 |         pub fn value(&self) -> Etype2 {
      |                                ^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1777:44
+error[E0412]: cannot find type `Etype3` in this scope
+    --> device_definition_errors.rs:1777:41
      |
-1777 |         pub fn set_value(&mut self, value: Etype2) {
+1777 |         pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+     |                                         ^^^^^^ not found in this scope
+     |
+help: you might be missing a type parameter
+     |
+1758 |     impl<Etype3> Fs2 {
+     |         ++++++++
+
+error[E0412]: cannot find type `Etype3` in this scope
+    --> device_definition_errors.rs:1777:50
+     |
+1777 |         pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+     |                                                  ^^^^^^ not found in this scope
+     |
+help: you might be missing a type parameter
+     |
+1758 |     impl<Etype3> Fs2 {
+     |         ++++++++
+
+error[E0412]: cannot find type `Etype2` in this scope
+    --> device_definition_errors.rs:1787:44
+     |
+1787 |         pub fn set_value(&mut self, value: Etype2) {
      |                                            ^^^^^^ not found in this scope
 
+error[E0412]: cannot find type `Etype3` in this scope
+    --> device_definition_errors.rs:1803:46
+     |
+1803 |         pub fn set_value_2(&mut self, value: Etype3) {
+     |                                              ^^^^^^ not found in this scope
+
 For more information about this error, try `rustc --explain E0412`.
-error: could not compile `device_definition_errors` (bin "device_definition_errors") due to 3 previous errors
+error: could not compile `device_definition_errors` (bin "device_definition_errors") due to 6 previous errors


### PR DESCRIPTION
I think this is the solution. No more weird switching between .into and .try_into.
Now only .try_into is used. When we determine it won't fail, we do an unsafe into.