### PR TITLE
Fix inconsistent word spliting logic

### DIFF
--- a/compiler/src/mir/lir_transform.rs
+++ b/compiler/src/mir/lir_transform.rs
@@ -1,5 +1,7 @@
 use std::ops::Add;
 
+use convert_case::Boundary;
+
 use crate::{
     lir,
     mir::{self, Manifest, Object},
@@ -99,6 +101,11 @@ fn get_method(
     manifest: &Manifest,
 ) -> Option<lir::BlockMethod> {
     use convert_case::Casing;
+    let default_word_boundary = Boundary::defaults();
+    let word_boundary = match &global_config.name_word_boundaries {
+        Some(name_word_boundaries) => name_word_boundaries.as_slice(),
+        None => default_word_boundary.as_slice(),
+    };
 
     match object {
         mir::Object::Device(_) => None,
@@ -120,7 +127,7 @@ fn get_method(
 
             Some(lir::BlockMethod {
                 description: description.clone(),
-                name: name.to_case(convert_case::Case::Snake),
+                name: name.with_boundaries(word_boundary).to_case(convert_case::Case::Snake),
                 address: address_offset.value,
                 allow_address_overlap: false,
                 repeat: repeat_to_method_kind(repeat, manifest),
@@ -140,7 +147,7 @@ fn get_method(
             reset_value,
         }) => Some(lir::BlockMethod {
             description: description.clone(),
-            name: name.to_case(convert_case::Case::Snake),
+            name: name.with_boundaries(word_boundary).to_case(convert_case::Case::Snake),
             address: address.value,
             allow_address_overlap: *allow_address_overlap,
             repeat: repeat_to_method_kind(repeat, manifest),
@@ -171,7 +178,7 @@ fn get_method(
             ..
         }) => Some(lir::BlockMethod {
             description: description.clone(),
-            name: name.to_case(convert_case::Case::Snake),
+            name: name.with_boundaries(word_boundary).to_case(convert_case::Case::Snake),
             address: address.value,
             allow_address_overlap: *allow_address_overlap,
             repeat: repeat_to_method_kind(repeat, manifest),
@@ -191,7 +198,7 @@ fn get_method(
             address,
         }) => Some(lir::BlockMethod {
             description: description.clone(),
-            name: name.to_case(convert_case::Case::Snake),
+            name: name.with_boundaries(word_boundary).to_case(convert_case::Case::Snake),
             address: address.value,
             allow_address_overlap: false,
             repeat: lir::Repeat::None, // Buffers can't be repeated (for now?)


### PR DESCRIPTION
Fix https://github.com/diondokter/device-driver/issues/166