### PR TITLE
Try new multi-register implementation

### DIFF
--- a/compiler/src/lir/mod.rs
+++ b/compiler/src/lir/mod.rs
@@ -25,6 +25,9 @@ pub struct Block {
     pub root: bool,
     pub name: Identifier,
     pub methods: Vec<BlockMethod>,
+    pub register_address_type: Integer,
+    pub command_address_type: Integer,
+    pub buffer_address_type: Integer,
 }
 
 pub struct BlockMethod {
@@ -55,17 +58,14 @@ pub enum BlockMethodType {
     Register {
         field_set_name: Identifier,
         access: Access,
-        address_type: Integer,
         reset_value: Option<Vec<u8>>,
     },
     Command {
         field_set_name_in: Option<Identifier>,
         field_set_name_out: Option<Identifier>,
-        address_type: Integer,
     },
     Buffer {
         access: Access,
-        address_type: Integer,
     },
 }
 

--- a/compiler/src/lir/mod.rs
+++ b/compiler/src/lir/mod.rs
@@ -41,13 +41,13 @@ pub struct BlockMethod {
 pub enum Repeat {
     None,
     Count {
-        count: u64,
-        stride: i128,
+        count: u16,
+        stride: i32,
     },
     Enum {
         enum_name: Identifier,
         enum_variants: Vec<Identifier>,
-        stride: i128,
+        stride: i32,
     },
 }
 
@@ -147,7 +147,7 @@ impl Enum {
 pub struct EnumVariant {
     pub description: String,
     pub name: Identifier,
-    pub discriminant: i128,
+    pub discriminant: i32,
     pub default: bool,
     pub catch_all: bool,
 }

--- a/compiler/src/mir/mod.rs
+++ b/compiler/src/mir/mod.rs
@@ -656,12 +656,12 @@ pub struct Block {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Repeat {
     pub source: RepeatSource,
-    pub stride: i128,
+    pub stride: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RepeatSource {
-    Count(u64),
+    Count(u16),
     Enum(Spanned<IdentifierRef>),
 }
 
@@ -816,7 +816,7 @@ impl Enum {
     ///
     /// *Note:* The validity of this is checked in the [`passes::enum_values_checked`] pass. If this function is run
     /// before that pass, there might be weird results.
-    pub fn iter_variants_with_discriminant(&self) -> impl Iterator<Item = (i128, &EnumVariant)> {
+    pub fn iter_variants_with_discriminant(&self) -> impl Iterator<Item = (i32, &EnumVariant)> {
         let mut next_discriminant = 0;
         self.variants.iter().map(move |variant| {
             if let EnumValue::Specified(discriminant) = variant.value {
@@ -836,7 +836,7 @@ impl Enum {
     /// before that pass, there might be weird results.
     pub fn iter_variants_with_discriminant_mut(
         &mut self,
-    ) -> impl Iterator<Item = (i128, &mut EnumVariant)> {
+    ) -> impl Iterator<Item = (i32, &mut EnumVariant)> {
         let mut next_discriminant = 0;
         self.variants.iter_mut().map(move |variant| {
             if let EnumValue::Specified(discriminant) = variant.value {
@@ -883,7 +883,7 @@ pub struct EnumVariant {
 pub enum EnumValue {
     #[default]
     Unspecified,
-    Specified(i128),
+    Specified(i32),
     Default,
     CatchAll,
 }

--- a/compiler/src/mir/passes/addresses_non_overlapping.rs
+++ b/compiler/src/mir/passes/addresses_non_overlapping.rs
@@ -88,7 +88,7 @@ fn find_object_addresses<'m>(
             match repeat.source {
                 RepeatSource::Count(count) => {
                     for index in 0..i128::from(count) {
-                        let repeat_offset = index * repeat.stride;
+                        let repeat_offset = index * repeat.stride as i128;
                         let address = total_address_offsets + address.value + repeat_offset;
 
                         object_addresses.push(ObjectAddress {
@@ -106,7 +106,7 @@ fn find_object_addresses<'m>(
                         .expect("A mir pass checked this is an enum");
 
                     for (discriminant, _) in enum_value.iter_variants_with_discriminant() {
-                        let repeat_offset = discriminant * repeat.stride;
+                        let repeat_offset = (discriminant * repeat.stride) as i128;
                         let address = total_address_offsets + address.value + repeat_offset;
 
                         object_addresses.push(ObjectAddress {

--- a/compiler/src/mir/passes/bit_ranges_validated.rs
+++ b/compiler/src/mir/passes/bit_ranges_validated.rs
@@ -119,7 +119,7 @@ fn get_repeat_iter(manifest: &Manifest, field: &crate::mir::Field) -> (Vec<i128>
         match &repeat.source {
             RepeatSource::Count(count) => (
                 (0..i128::from(*count))
-                    .map(move |count| count * stride)
+                    .map(move |count| count * stride as i128)
                     .collect(),
                 true,
             ),
@@ -129,7 +129,7 @@ fn get_repeat_iter(manifest: &Manifest, field: &crate::mir::Field) -> (Vec<i128>
                     .as_enum()
                     .expect("Checked in earlier pass")
                     .iter_variants_with_discriminant()
-                    .map(move |(discriminant, _)| discriminant * stride)
+                    .map(move |(discriminant, _)| (discriminant * stride) as i128)
                     .collect(),
                 true,
             ),

--- a/compiler/src/mir/passes/enum_values_checked.rs
+++ b/compiler/src/mir/passes/enum_values_checked.rs
@@ -48,7 +48,7 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) -> HashS
             })
             .collect_vec();
 
-        let mut seen_values_map = HashMap::<i128, Vec<&UniqueId>>::new();
+        let mut seen_values_map = HashMap::<i32, Vec<&UniqueId>>::new();
         for (variant_value, variant_id) in &seen_values {
             seen_values_map
                 .entry(*variant_value)
@@ -79,8 +79,8 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) -> HashS
 
         let base_type_integer = match enum_value.base_type.value {
             BaseType::Unspecified => Integer::find_smallest(
-                *seen_min,
-                *seen_max,
+                *seen_min as i128,
+                *seen_max as i128,
                 enum_value.size_bits.unwrap_or_default(),
             ),
             BaseType::Bool => {
@@ -95,8 +95,8 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) -> HashS
             }
             BaseType::Uint => {
                 let integer = Integer::find_smallest(
-                    *seen_min,
-                    *seen_max,
+                    *seen_min as i128,
+                    *seen_max as i128,
                     enum_value.size_bits.unwrap_or_default(),
                 );
 
@@ -114,8 +114,8 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) -> HashS
                 integer
             }
             BaseType::Int => Integer::find_smallest(
-                (*seen_min).min(-1),
-                *seen_max,
+                (*seen_min as i128).min(-1),
+                *seen_max as i128,
                 enum_value.size_bits.unwrap_or_default(),
             ),
             BaseType::FixedSize(integer) => {
@@ -153,7 +153,7 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) -> HashS
         };
 
         let size_bits = match enum_value.size_bits {
-            None => base_type_integer.bits_required(*seen_min, *seen_max),
+            None => base_type_integer.bits_required(*seen_min as i128, *seen_max as i128),
             Some(size_bits) => size_bits,
         };
 

--- a/compiler/src/mir/passes/mod.rs
+++ b/compiler/src/mir/passes/mod.rs
@@ -101,8 +101,8 @@ pub(crate) fn find_min_max_addresses<'m>(
             match repeat.source {
                 RepeatSource::Count(count) => {
                     let count_0_address = total_address_offsets + address.value;
-                    let count_max_address =
-                        count_0_address + (i128::from(count.saturating_sub(1)) * repeat.stride);
+                    let count_max_address = count_0_address
+                        + (i128::from(count.saturating_sub(1)) * repeat.stride as i128);
                     let min_address = count_0_address.min(count_max_address);
                     let max_address = count_0_address.max(count_max_address);
 
@@ -123,8 +123,9 @@ pub(crate) fn find_min_max_addresses<'m>(
                         .expect("A mir pass checked this is an enum");
 
                     for (discriminant, _) in enum_value.iter_variants_with_discriminant() {
-                        let address =
-                            total_address_offsets + address.value + (discriminant * repeat.stride);
+                        let address = total_address_offsets
+                            + address.value
+                            + (discriminant * repeat.stride) as i128;
                         if address < min_address_found {
                             min_address_found = address;
                             min_obj_found = Some(object);

--- a/compiler/src/reporting/errors.rs
+++ b/compiler/src/reporting/errors.rs
@@ -338,7 +338,7 @@ pub struct EmptyEnum {
 pub struct DuplicateVariantValue {
     #[label(collection)]
     pub duplicates: Vec<SourceSpan>,
-    pub value: i128,
+    pub value: i32,
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -395,7 +395,7 @@ pub struct VariantValuesTooHigh {
     pub variant_names: Vec<SourceSpan>,
     #[label("Part of this enum")]
     pub enum_name: SourceSpan,
-    pub max_value: i128,
+    pub max_value: i32,
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -409,7 +409,7 @@ pub struct VariantValuesTooLow {
     pub variant_names: Vec<SourceSpan>,
     #[label("Part of this enum")]
     pub enum_name: SourceSpan,
-    pub min_value: i128,
+    pub min_value: i32,
 }
 
 #[derive(Error, Debug, Diagnostic)]

--- a/compiler/templates/rust/block.rs.j2
+++ b/compiler/templates/rust/block.rs.j2
@@ -34,83 +34,16 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
     {% endif %}
 
     {% for method in block.methods %}
-        {{ self::description_to_docstring(method.description) }}
-        {% match method.repeat %}
-            {% when Repeat::None %}
-            {% when Repeat::Count { count, .. } %}
-            ///
-            /// Valid index range: 0..{{count}}
-            {% when Repeat::Enum { .. } %}
-            {% endwhen %}
-        {% endmatch %}
-        pub fn {{ method.name.to_case(Case::Snake) }}(
-            &mut self,
-            {% match method.repeat %}
-                {% when Repeat::None %}
-                {% when Repeat::Count { .. } %} index: usize
-                {% when Repeat::Enum { enum_name, .. } %} index: {{enum_name.to_case(Case::Pascal)}}
-            {% endmatch %}
-        ) -> 
         {% match method.method_type %}
-            {% when BlockMethodType::Block { name } %} {{name.to_case(Case::Pascal)}}<'_, I>
-            {% when BlockMethodType::Register { field_set_name, access, .. } %} ::device_driver::RegisterOperation<'_, I, {{block.register_address_type}}, {{field_set_name.to_case(Case::Pascal)}}, ::device_driver::{{access}}>
-            {% when BlockMethodType::Command { field_set_name_in, field_set_name_out } %} ::device_driver::CommandOperation<'_, I, {{block.command_address_type}}, {{self::get_command_fieldset_name(field_set_name_in)}}, {{self::get_command_fieldset_name(field_set_name_out)}}>
-            {% when BlockMethodType::Buffer { access } %} ::device_driver::BufferOperation<'_, I, {{block.buffer_address_type}}, ::device_driver::{{access}}>
+            {% when BlockMethodType::Block { name } %}
+                {% include "methods/block.rs.j2" %}
+            {% when BlockMethodType::Register { field_set_name, access, reset_value } %}
+                {% include "methods/register.rs.j2" %}
+            {% when BlockMethodType::Command { field_set_name_in, field_set_name_out } %}
+                {% include "methods/command.rs.j2" %}
+            {% when BlockMethodType::Buffer { access } %}
+                {% include "methods/buffer.rs.j2" %}
         {% endmatch %}
-        {
-            use ::device_driver::Block;
-
-            {% match method.repeat %}
-                {% when Repeat::None %} let address = self.base_address + {{method.address}};
-                {% when Repeat::Count { count, stride } %}
-                    let address = {
-                        assert!(index < {{count}});
-                        self.base_address + {{method.address}} + index as {{device.internal_address_type}} * {{stride}}
-                    };
-                {% when Repeat::Enum { enum_name, stride, .. } %}
-                    let address = self.base_address + {{method.address}} + {{self::get_enum_base_type(driver, &enum_name)}}::from(index) as {{device.internal_address_type}} * {{stride}};
-            {% endmatch %}
-
-            {% match method.method_type %}
-                {% when BlockMethodType::Block { name } %}
-                    {{name.to_case(Case::Pascal)}}::<'_, I>::new(self.interface(), address)
-                {% endwhen %}
-                {% when BlockMethodType::Register { field_set_name, access, reset_value } %}
-                    ::device_driver::RegisterOperation::<
-                        '_,
-                        I,
-                        {{block.register_address_type}},
-                        {{field_set_name.to_case(Case::Pascal)}},
-                        ::device_driver::{{access}},
-                    >::new(
-                        self.interface(),
-                        address as {{block.register_address_type}},
-                        {% if let Some(rv) = reset_value %}
-                            || {{field_set_name.to_case(Case::Pascal)}}::from([{{rv | join(", ")}}]),
-                        {% else %}
-                            {{field_set_name.to_case(Case::Pascal)}}::new,
-                        {% endif %}
-                        )
-                {% endwhen %}
-                {% when BlockMethodType::Command { field_set_name_in, field_set_name_out } %}
-                    ::device_driver::CommandOperation::<
-                        '_,
-                        I,
-                        {{block.command_address_type}},
-                        {{self::get_command_fieldset_name(field_set_name_in)}},
-                        {{self::get_command_fieldset_name(field_set_name_out)}},
-                    >::new(self.interface(), address as {{block.command_address_type}})
-                {% endwhen %}
-                {% when BlockMethodType::Buffer { access } %}
-                    ::device_driver::BufferOperation::<
-                        '_,
-                        I,
-                        {{block.buffer_address_type}},
-                        ::device_driver::{{access}},
-                    >::new(self.interface(), address as {{block.buffer_address_type}})
-                {% endwhen %}
-            {% endmatch %}
-        }
     {% endfor %}
 }
 

--- a/compiler/templates/rust/block.rs.j2
+++ b/compiler/templates/rust/block.rs.j2
@@ -9,9 +9,11 @@
 #[derive(Debug)]
 pub struct {{ block.name.to_case(Case::Pascal) }}{{block_generics}} {
     {% if block.root %}
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     {% else %}
-    pub(crate) interface: &'i mut I,
+    #[doc(hidden)]
+    interface: &'i mut I,
     {% endif %}
     #[doc(hidden)]
     base_address: {{device.internal_address_type}},
@@ -19,25 +21,15 @@ pub struct {{ block.name.to_case(Case::Pascal) }}{{block_generics}} {
 
 impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} {
     {% if block.root %}
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     {% else %}
     /// Create a new instance of the block based on device interface
     #[doc(hidden)]
     fn new(interface: &'i mut I, base_address: {{device.internal_address_type}}) -> Self {
         Self { interface, base_address: base_address }
-    }
-
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        self.interface
     }
     {% endif %}
 
@@ -61,11 +53,13 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
         ) -> 
         {% match method.method_type %}
             {% when BlockMethodType::Block { name } %} {{name.to_case(Case::Pascal)}}<'_, I>
-            {% when BlockMethodType::Register { field_set_name, access, address_type, .. } %} ::device_driver::RegisterOperation<'_, I, {{address_type}}, {{field_set_name.to_case(Case::Pascal)}}, ::device_driver::{{access}}>
-            {% when BlockMethodType::Command { field_set_name_in, field_set_name_out, address_type } %} ::device_driver::CommandOperation<'_, I, {{address_type}}, {{self::get_command_fieldset_name(field_set_name_in)}}, {{self::get_command_fieldset_name(field_set_name_out)}}>
-            {% when BlockMethodType::Buffer { access, address_type } %} ::device_driver::BufferOperation<'_, I, {{address_type}}, ::device_driver::{{access}}>
+            {% when BlockMethodType::Register { field_set_name, access, .. } %} ::device_driver::RegisterOperation<'_, I, {{block.register_address_type}}, {{field_set_name.to_case(Case::Pascal)}}, ::device_driver::{{access}}>
+            {% when BlockMethodType::Command { field_set_name_in, field_set_name_out } %} ::device_driver::CommandOperation<'_, I, {{block.command_address_type}}, {{self::get_command_fieldset_name(field_set_name_in)}}, {{self::get_command_fieldset_name(field_set_name_out)}}>
+            {% when BlockMethodType::Buffer { access } %} ::device_driver::BufferOperation<'_, I, {{block.buffer_address_type}}, ::device_driver::{{access}}>
         {% endmatch %}
         {
+            use ::device_driver::Block;
+
             {% match method.repeat %}
                 {% when Repeat::None %} let address = self.base_address + {{method.address}};
                 {% when Repeat::Count { count, stride } %}
@@ -81,16 +75,16 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
                 {% when BlockMethodType::Block { name } %}
                     {{name.to_case(Case::Pascal)}}::<'_, I>::new(self.interface(), address)
                 {% endwhen %}
-                {% when BlockMethodType::Register { field_set_name, access, address_type, reset_value } %}
+                {% when BlockMethodType::Register { field_set_name, access, reset_value } %}
                     ::device_driver::RegisterOperation::<
                         '_,
                         I,
-                        {{address_type}},
+                        {{block.register_address_type}},
                         {{field_set_name.to_case(Case::Pascal)}},
                         ::device_driver::{{access}},
                     >::new(
                         self.interface(),
-                        address as {{address_type}},
+                        address as {{block.register_address_type}},
                         {% if let Some(rv) = reset_value %}
                             || {{field_set_name.to_case(Case::Pascal)}}::from([{{rv | join(", ")}}]),
                         {% else %}
@@ -98,24 +92,39 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
                         {% endif %}
                         )
                 {% endwhen %}
-                {% when BlockMethodType::Command { field_set_name_in, field_set_name_out, address_type } %}
+                {% when BlockMethodType::Command { field_set_name_in, field_set_name_out } %}
                     ::device_driver::CommandOperation::<
                         '_,
                         I,
-                        {{address_type}},
+                        {{block.command_address_type}},
                         {{self::get_command_fieldset_name(field_set_name_in)}},
                         {{self::get_command_fieldset_name(field_set_name_out)}},
-                    >::new(self.interface(), address as {{address_type}})
+                    >::new(self.interface(), address as {{block.command_address_type}})
                 {% endwhen %}
-                {% when BlockMethodType::Buffer { access, address_type } %}
+                {% when BlockMethodType::Buffer { access } %}
                     ::device_driver::BufferOperation::<
                         '_,
                         I,
-                        {{address_type}},
+                        {{block.buffer_address_type}},
                         ::device_driver::{{access}},
-                    >::new(self.interface(), address as {{address_type}})
+                    >::new(self.interface(), address as {{block.buffer_address_type}})
                 {% endwhen %}
             {% endmatch %}
         }
     {% endfor %}
+}
+
+impl{{block_generics}} ::device_driver::Block for {{ block.name.to_case(Case::Pascal) }}{{block_generics}} {
+    type Interface = I;
+    type RegisterAddressType = {{block.register_address_type}};
+    type CommandAddressType = {{block.command_address_type}};
+    type BufferAddressType = {{block.buffer_address_type}};
+
+    fn interface(&mut self) -> &mut Self::Interface {
+        {% if block.root %}
+        &mut self.interface
+        {% else %}
+        self.interface
+        {% endif %}
+    }
 }

--- a/compiler/templates/rust/fieldset.rs.j2
+++ b/compiler/templates/rust/fieldset.rs.j2
@@ -7,12 +7,26 @@ pub struct {{field_set.name.to_case(Case::Pascal)}} {
 }
 
 unsafe impl ::device_driver::FieldSet for {{field_set.name.to_case(Case::Pascal)}} {
+    type Unpacked = Self;
+
     const SIZE_BITS: u32 = {{field_set.size_bits}};
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+
+impl ::device_driver::UnpackedFieldSet for {{field_set.name.to_case(Case::Pascal)}} {
+    type Packed = Self;
+
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 

--- a/compiler/templates/rust/fieldset.rs.j2
+++ b/compiler/templates/rust/fieldset.rs.j2
@@ -1,11 +1,12 @@
 {{self::description_to_docstring(field_set.description)}}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct {{field_set.name.to_case(Case::Pascal)}} {
     /// The internal bits
     bits: [u8; {{field_set.size_bytes()}}]
 }
 
-impl ::device_driver::FieldSet for {{field_set.name.to_case(Case::Pascal)}} {
+unsafe impl ::device_driver::FieldSet for {{field_set.name.to_case(Case::Pascal)}} {
     const SIZE_BITS: u32 = {{field_set.size_bits}};
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/compiler/templates/rust/methods/block.rs.j2
+++ b/compiler/templates/rust/methods/block.rs.j2
@@ -1,0 +1,33 @@
+{{ self::description_to_docstring(method.description) }}
+{% match method.repeat %}
+    {% when Repeat::None %}
+    {% when Repeat::Count { count, .. } %}
+    ///
+    /// Valid index range: 0..{{count}}
+    {% when Repeat::Enum { .. } %}
+    {% endwhen %}
+{% endmatch %}
+pub fn {{ method.name.to_case(Case::Snake) }}(
+    &mut self,
+    {% match method.repeat %}
+        {% when Repeat::None %}
+        {% when Repeat::Count { .. } %} index: usize
+        {% when Repeat::Enum { enum_name, .. } %} index: {{enum_name.to_case(Case::Pascal)}}
+    {% endmatch %}
+) -> {{name.to_case(Case::Pascal)}}<'_, I>
+{
+    use ::device_driver::Block;
+
+    {% match method.repeat %}
+        {% when Repeat::None %} let address = self.base_address + {{method.address}};
+        {% when Repeat::Count { count, stride } %}
+            let address = {
+                assert!(index < {{count}});
+                self.base_address + {{method.address}} + index as {{device.internal_address_type}} * {{stride}}
+            };
+        {% when Repeat::Enum { enum_name, stride, .. } %}
+            let address = self.base_address + {{method.address}} + {{self::get_enum_base_type(driver, &enum_name)}}::from(index) as {{device.internal_address_type}} * {{stride}};
+    {% endmatch %}
+
+    {{name.to_case(Case::Pascal)}}::<'_, I>::new(self.interface(), address)
+}

--- a/compiler/templates/rust/methods/buffer.rs.j2
+++ b/compiler/templates/rust/methods/buffer.rs.j2
@@ -1,0 +1,6 @@
+{{ self::description_to_docstring(method.description) }}
+pub fn {{ method.name.to_case(Case::Snake) }}(&mut self) -> ::device_driver::BufferOperation<'_, I, {{block.buffer_address_type}}, ::device_driver::{{access}}> {
+    use ::device_driver::Block;
+    let address = self.base_address + {{method.address}};
+    ::device_driver::BufferOperation::new(self.interface(), address as {{block.buffer_address_type}})
+}

--- a/compiler/templates/rust/methods/command.rs.j2
+++ b/compiler/templates/rust/methods/command.rs.j2
@@ -1,0 +1,27 @@
+{{ self::description_to_docstring(method.description) }}
+{% match method.repeat %}
+    {% when Repeat::None %}
+    {% when Repeat::Count { count, .. } %}
+    ///
+    /// Valid index range: 0..{{count}}
+    {% when Repeat::Enum { .. } %}
+    {% endwhen %}
+{% endmatch %}
+pub fn {{ method.name.to_case(Case::Snake) }}(&mut self) -> 
+    ::device_driver::CommandOperation<
+        '_,
+        I,
+        {{block.command_address_type}},
+        {{self::get_command_fieldset_name(field_set_name_in)}},
+        {{self::get_command_fieldset_name(field_set_name_out)}},
+        {% match method.repeat %}
+            {% when Repeat::None %} ()
+            {% when Repeat::Count { count, stride } %} ::device_driver::ArrayRepeat<{{count}}, {{stride}}>
+            {% when Repeat::Enum { enum_name, stride, .. } %} ::device_driver::EnumRepeat<{{enum_name.to_case(Case::Pascal)}}, {{stride}}>
+        {% endmatch %}
+    >
+{
+    use ::device_driver::Block;
+    let address = self.base_address + {{method.address}};
+    ::device_driver::CommandOperation::new(self.interface(), address as {{block.command_address_type}})
+}

--- a/compiler/templates/rust/methods/register.rs.j2
+++ b/compiler/templates/rust/methods/register.rs.j2
@@ -1,0 +1,36 @@
+{{ self::description_to_docstring(method.description) }}
+{% match method.repeat %}
+    {% when Repeat::None %}
+    {% when Repeat::Count { count, .. } %}
+    ///
+    /// Valid index range: 0..{{count}}
+    {% when Repeat::Enum { .. } %}
+    {% endwhen %}
+{% endmatch %}
+pub fn {{ method.name.to_case(Case::Snake) }}(&mut self) -> 
+    ::device_driver::RegisterOperation<
+        '_,
+        I,
+        {{block.register_address_type}},
+        {{field_set_name.to_case(Case::Pascal)}},
+        ::device_driver::{{access}},
+        {% match method.repeat %}
+            {% when Repeat::None %} ()
+            {% when Repeat::Count { count, stride } %} ::device_driver::ArrayRepeat<{{count}}, {{stride}}>
+            {% when Repeat::Enum { enum_name, stride, .. } %} ::device_driver::EnumRepeat<{{enum_name.to_case(Case::Pascal)}}, {{stride}}>
+        {% endmatch %}
+    >
+{
+    use ::device_driver::Block;
+    let address = self.base_address + {{method.address}};
+
+    ::device_driver::RegisterOperation::new(
+        self.interface(),
+        address as {{block.register_address_type}},
+        {% if let Some(rv) = reset_value %}
+            || {{field_set_name.to_case(Case::Pascal)}}::from([{{rv | join(", ")}}]),
+        {% else %}
+            {{field_set_name.to_case(Case::Pascal)}}::new,
+        {% endif %}
+        )
+}

--- a/device-driver/src/command.rs
+++ b/device-driver/src/command.rs
@@ -88,6 +88,7 @@ where
     }
 
     /// Dispatch the command to the device
+    #[track_caller]
     pub fn dispatch_at(self, index: Form::Index) -> Result<(), Interface::Error>
     where
         Interface: CommandInterface<AddressType = AddressType>,
@@ -146,6 +147,7 @@ where
     }
 
     /// Dispatch the command to the device
+    #[track_caller]
     pub fn dispatch_at(
         self,
         index: Form::Index,
@@ -242,6 +244,7 @@ where
     }
 
     /// Dispatch the command to the device
+    #[track_caller]
     pub fn dispatch_at(self, index: Form::Index) -> Result<OutFieldSet, Interface::Error>
     where
         Interface: CommandInterface<AddressType = AddressType>,
@@ -337,6 +340,7 @@ where
     }
 
     /// Dispatch the command to the device
+    #[track_caller]
     pub fn dispatch_at(
         self,
         index: Form::Index,

--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -1,7 +1,8 @@
 use core::marker::PhantomData;
 
 use crate::{
-    Address, Block, FieldSet, FsSet, NotRepeating, RO, RW, ReadCapability, Repeating, WO, WriteCapability
+    Address, Block, FieldSet, FsSet, NotRepeating, RO, RW, ReadCapability, Repeating, WO,
+    WriteCapability,
 };
 
 /// A trait to represent the interface to the device.

--- a/device-driver/tests/basic-register-manifest.rs
+++ b/device-driver/tests/basic-register-manifest.rs
@@ -85,15 +85,15 @@ fn test_basic_read_modify_write() {
 #[should_panic]
 fn test_repeated_too_large_index() {
     let mut device = MyTestDevice::new(DeviceInterface::new());
-    device.foo_repeated(4);
+    device.foo_repeated().plan_at(4);
 }
 
 #[test]
 fn test_repeated_read_modify_write() {
     let mut device = MyTestDevice::new(DeviceInterface::new());
     device
-        .foo_repeated(2)
-        .modify(|reg| {
+        .foo_repeated()
+        .modify_at(2, |reg| {
             reg.set_value_0(true);
             reg.set_value_1(12345);
             reg.set_value_2(-1);

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -1,4 +1,6 @@
-use device_driver::RegisterInterface;
+use std::marker::PhantomData;
+
+use device_driver::{FsSet, RegisterInterface};
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -28,7 +30,7 @@ impl RegisterInterface for DeviceInterface {
         size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        // assert_eq!(size_bits, 24);
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
 
         Ok(())
@@ -40,7 +42,7 @@ impl RegisterInterface for DeviceInterface {
         size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        // assert_eq!(size_bits, 24);
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
         Ok(())
     }
@@ -54,6 +56,7 @@ device_driver::create_device!(
             /// This is the Foo register
             register Foo {
                 address 0
+                reset-value 0xFFFFFF
                 fields size-bits=24 {
                     /// This is a bool!
                     (bool)value0 @0
@@ -75,6 +78,303 @@ device_driver::create_device!(
         }
     "
 );
+
+#[test]
+fn multi_test() {
+    let mut device = MyTestDevice::new(DeviceInterface::new());
+
+    device
+        .multi_write()
+        .with(|d| {
+            d.foo_repeated(0)
+                .plan_write_with_zero(|reg| reg.set_value_1(42))
+        })
+        .with(|d| d.foo().plan_write(|_| {}))
+        .execute()
+        .unwrap();
+
+    let multi = device
+        .multi_read()
+        // TODO: Allow reading multiple. This would return a [FooRepeated;N] that can also impl FieldSet.
+        // Maybe N is a const generic on foo_repeated with default 1?
+        // We'll also need a check whether it's allowed by the device rules. That's probably an assert.
+        .with(|d| d.foo_repeated(0).plan_read())
+        .with(|d| d.foo().plan_read())
+        .execute()
+        .unwrap();
+
+    println!("{multi:?}");
+
+    device
+        .multi_modify()
+        .with(|d| d.foo_repeated(0).plan_modify())
+        .with(|d| d.foo().plan_modify())
+        .execute(|(foo_repeat_0, foo)| {
+            foo_repeat_0.set_value_2(-5);
+            foo.set_value_0(false);
+        })
+        .unwrap();
+
+    let multi = device
+        .multi_read()
+        .with(|d| d.foo_repeated(0).plan_read())
+        .with(|d| d.foo().plan_read())
+        .execute()
+        .unwrap();
+
+    println!("{multi:?}");
+}
+
+pub struct MultiRegisterOperation<'d, D, AddressType, FieldSets: FsSet, Access> {
+    device: &'d mut D,
+    start_address: Option<AddressType>,
+    field_sets: FieldSets,
+    bit_sum: u32,
+    _phantom: PhantomData<Access>,
+}
+
+impl<'d, D, AddressType, FieldSets: FsSet>
+    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::RO>
+where
+    D: Device,
+    AddressType: Copy,
+{
+    #[inline]
+    pub fn with<FS: device_driver::FieldSet, LocalAccess: device_driver::ReadCapability>(
+        mut self,
+        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
+    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::RO>
+    where
+        FieldSets::Next<FS>: FsSet,
+    {
+        let plan = f(self.device);
+        if self.start_address.is_none() {
+            self.start_address = Some(plan.address)
+        }
+        assert!(FS::SIZE_BITS.is_multiple_of(8));
+
+        // TODO: Check if legal
+
+        MultiRegisterOperation {
+            device: self.device,
+            start_address: self.start_address,
+            field_sets: self.field_sets.push(plan.value),
+            bit_sum: self.bit_sum + FS::SIZE_BITS,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d, D, AddressType, FieldSets: FsSet>
+    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::WO>
+where
+    D: Device,
+    AddressType: Copy,
+{
+    #[inline]
+    pub fn with<FS: device_driver::FieldSet, LocalAccess: device_driver::WriteCapability>(
+        mut self,
+        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
+    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::WO>
+    where
+        FieldSets::Next<FS>: FsSet,
+    {
+        let plan = f(self.device);
+        if self.start_address.is_none() {
+            self.start_address = Some(plan.address)
+        }
+        assert!(FS::SIZE_BITS.is_multiple_of(8));
+
+        // TODO: Check if legal
+
+        MultiRegisterOperation {
+            device: self.device,
+            start_address: self.start_address,
+            field_sets: self.field_sets.push(plan.value),
+            bit_sum: self.bit_sum + FS::SIZE_BITS,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d, D, AddressType, FieldSets: FsSet>
+    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::RW>
+where
+    D: Device,
+    AddressType: Copy,
+{
+    #[inline]
+    pub fn with<
+        FS: device_driver::FieldSet,
+        LocalAccess: device_driver::WriteCapability + device_driver::ReadCapability,
+    >(
+        mut self,
+        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
+    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::RW>
+    where
+        FieldSets::Next<FS>: FsSet,
+    {
+        let plan = f(self.device);
+        if self.start_address.is_none() {
+            self.start_address = Some(plan.address)
+        }
+        assert!(FS::SIZE_BITS.is_multiple_of(8));
+
+        // TODO: Check if legal
+
+        MultiRegisterOperation {
+            device: self.device,
+            start_address: self.start_address,
+            field_sets: self.field_sets.push(plan.value),
+            bit_sum: self.bit_sum + FS::SIZE_BITS,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d, D, FieldSets: FsSet>
+    MultiRegisterOperation<
+        'd,
+        D,
+        <D::Interface as device_driver::RegisterInterface>::AddressType,
+        FieldSets,
+        device_driver::RO,
+    >
+where
+    D: Device,
+    D::Interface: device_driver::RegisterInterface,
+{
+    #[inline]
+    pub fn execute(
+        mut self,
+    ) -> Result<FieldSets::Value, <D::Interface as device_driver::RegisterInterface>::Error> {
+        let data = self.field_sets.as_slice_mut();
+        self.device
+            .interface()
+            .read_register(self.start_address.unwrap(), self.bit_sum, data)?;
+        Ok(self.field_sets.to_value())
+    }
+}
+
+impl<'d, D, FieldSets: FsSet>
+    MultiRegisterOperation<
+        'd,
+        D,
+        <D::Interface as device_driver::RegisterInterface>::AddressType,
+        FieldSets,
+        device_driver::WO,
+    >
+where
+    D: Device,
+    D::Interface: device_driver::RegisterInterface,
+{
+    #[inline]
+    pub fn execute(
+        mut self,
+    ) -> Result<FieldSets::Value, <D::Interface as device_driver::RegisterInterface>::Error> {
+        let data = self.field_sets.as_slice_mut();
+        self.device
+            .interface()
+            .write_register(self.start_address.unwrap(), self.bit_sum, data)?;
+        Ok(self.field_sets.to_value())
+    }
+}
+
+impl<'d, D, FieldSets: FsSet>
+    MultiRegisterOperation<
+        'd,
+        D,
+        <D::Interface as device_driver::RegisterInterface>::AddressType,
+        FieldSets,
+        device_driver::RW,
+    >
+where
+    D: Device,
+    D::Interface: device_driver::RegisterInterface,
+{
+    #[inline]
+    pub fn execute<R>(
+        mut self,
+        f: impl FnOnce(FieldSets::ValueMut<'_>) -> R,
+    ) -> Result<R, <D::Interface as device_driver::RegisterInterface>::Error> {
+        self.device.interface().read_register(
+            self.start_address.unwrap(),
+            self.bit_sum,
+            self.field_sets.as_slice_mut(),
+        )?;
+
+        let returned = f(self.field_sets.as_value_mut());
+
+        self.device.interface().write_register(
+            self.start_address.unwrap(),
+            self.bit_sum,
+            self.field_sets.as_slice_mut(),
+        )?;
+
+        Ok(returned)
+    }
+}
+
+pub trait Device {
+    type Interface;
+    type AddressType;
+
+    fn interface(&mut self) -> &mut Self::Interface;
+
+    fn multi_read(
+        &mut self,
+    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::RO>
+    where
+        Self: Sized,
+    {
+        MultiRegisterOperation {
+            device: self,
+            start_address: None,
+            field_sets: (),
+            bit_sum: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn multi_write(
+        &mut self,
+    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::WO>
+    where
+        Self: Sized,
+    {
+        MultiRegisterOperation {
+            device: self,
+            start_address: None,
+            field_sets: (),
+            bit_sum: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn multi_modify(
+        &mut self,
+    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::RW>
+    where
+        Self: Sized,
+    {
+        MultiRegisterOperation {
+            device: self,
+            start_address: None,
+            field_sets: (),
+            bit_sum: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I> Device for MyTestDevice<I> {
+    type Interface = I;
+    type AddressType = u8;
+
+    fn interface(&mut self) -> &mut Self::Interface {
+        self.interface()
+    }
+}
 
 #[test]
 fn test_basic_read_modify_write() {

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -111,15 +111,15 @@ fn test_basic_read_modify_write() {
 #[should_panic]
 fn test_repeated_too_large_index() {
     let mut device = MyTestDevice::new(DeviceInterface::new());
-    device.foo_repeated(4);
+    device.foo_repeated().plan_at(4);
 }
 
 #[test]
 fn test_repeated_read_modify_write() {
     let mut device = MyTestDevice::new(DeviceInterface::new());
     device
-        .foo_repeated(2)
-        .modify(|reg| {
+        .foo_repeated()
+        .modify_at(2, |reg| {
             reg.set_value_0(true);
             reg.set_value_1(12345);
             reg.set_value_2(-1);

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -1,6 +1,4 @@
-use std::marker::PhantomData;
-
-use device_driver::{FsSet, RegisterInterface};
+use device_driver::RegisterInterface;
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -30,7 +28,7 @@ impl RegisterInterface for DeviceInterface {
         size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
-        // assert_eq!(size_bits, 24);
+        assert_eq!(size_bits, 24);
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
 
         Ok(())
@@ -42,7 +40,7 @@ impl RegisterInterface for DeviceInterface {
         size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        // assert_eq!(size_bits, 24);
+        assert_eq!(size_bits, 24);
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
         Ok(())
     }
@@ -56,7 +54,6 @@ device_driver::create_device!(
             /// This is the Foo register
             register Foo {
                 address 0
-                reset-value 0xFFFFFF
                 fields size-bits=24 {
                     /// This is a bool!
                     (bool)value0 @0
@@ -78,303 +75,6 @@ device_driver::create_device!(
         }
     "
 );
-
-#[test]
-fn multi_test() {
-    let mut device = MyTestDevice::new(DeviceInterface::new());
-
-    device
-        .multi_write()
-        .with(|d| {
-            d.foo_repeated(0)
-                .plan_write_with_zero(|reg| reg.set_value_1(42))
-        })
-        .with(|d| d.foo().plan_write(|_| {}))
-        .execute()
-        .unwrap();
-
-    let multi = device
-        .multi_read()
-        // TODO: Allow reading multiple. This would return a [FooRepeated;N] that can also impl FieldSet.
-        // Maybe N is a const generic on foo_repeated with default 1?
-        // We'll also need a check whether it's allowed by the device rules. That's probably an assert.
-        .with(|d| d.foo_repeated(0).plan_read())
-        .with(|d| d.foo().plan_read())
-        .execute()
-        .unwrap();
-
-    println!("{multi:?}");
-
-    device
-        .multi_modify()
-        .with(|d| d.foo_repeated(0).plan_modify())
-        .with(|d| d.foo().plan_modify())
-        .execute(|(foo_repeat_0, foo)| {
-            foo_repeat_0.set_value_2(-5);
-            foo.set_value_0(false);
-        })
-        .unwrap();
-
-    let multi = device
-        .multi_read()
-        .with(|d| d.foo_repeated(0).plan_read())
-        .with(|d| d.foo().plan_read())
-        .execute()
-        .unwrap();
-
-    println!("{multi:?}");
-}
-
-pub struct MultiRegisterOperation<'d, D, AddressType, FieldSets: FsSet, Access> {
-    device: &'d mut D,
-    start_address: Option<AddressType>,
-    field_sets: FieldSets,
-    bit_sum: u32,
-    _phantom: PhantomData<Access>,
-}
-
-impl<'d, D, AddressType, FieldSets: FsSet>
-    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::RO>
-where
-    D: Device,
-    AddressType: Copy,
-{
-    #[inline]
-    pub fn with<FS: device_driver::FieldSet, LocalAccess: device_driver::ReadCapability>(
-        mut self,
-        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
-    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::RO>
-    where
-        FieldSets::Next<FS>: FsSet,
-    {
-        let plan = f(self.device);
-        if self.start_address.is_none() {
-            self.start_address = Some(plan.address)
-        }
-        assert!(FS::SIZE_BITS.is_multiple_of(8));
-
-        // TODO: Check if legal
-
-        MultiRegisterOperation {
-            device: self.device,
-            start_address: self.start_address,
-            field_sets: self.field_sets.push(plan.value),
-            bit_sum: self.bit_sum + FS::SIZE_BITS,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<'d, D, AddressType, FieldSets: FsSet>
-    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::WO>
-where
-    D: Device,
-    AddressType: Copy,
-{
-    #[inline]
-    pub fn with<FS: device_driver::FieldSet, LocalAccess: device_driver::WriteCapability>(
-        mut self,
-        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
-    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::WO>
-    where
-        FieldSets::Next<FS>: FsSet,
-    {
-        let plan = f(self.device);
-        if self.start_address.is_none() {
-            self.start_address = Some(plan.address)
-        }
-        assert!(FS::SIZE_BITS.is_multiple_of(8));
-
-        // TODO: Check if legal
-
-        MultiRegisterOperation {
-            device: self.device,
-            start_address: self.start_address,
-            field_sets: self.field_sets.push(plan.value),
-            bit_sum: self.bit_sum + FS::SIZE_BITS,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<'d, D, AddressType, FieldSets: FsSet>
-    MultiRegisterOperation<'d, D, AddressType, FieldSets, device_driver::RW>
-where
-    D: Device,
-    AddressType: Copy,
-{
-    #[inline]
-    pub fn with<
-        FS: device_driver::FieldSet,
-        LocalAccess: device_driver::WriteCapability + device_driver::ReadCapability,
-    >(
-        mut self,
-        f: impl FnOnce(&mut D) -> device_driver::Plan<AddressType, FS, LocalAccess>,
-    ) -> MultiRegisterOperation<'d, D, AddressType, FieldSets::Next<FS>, device_driver::RW>
-    where
-        FieldSets::Next<FS>: FsSet,
-    {
-        let plan = f(self.device);
-        if self.start_address.is_none() {
-            self.start_address = Some(plan.address)
-        }
-        assert!(FS::SIZE_BITS.is_multiple_of(8));
-
-        // TODO: Check if legal
-
-        MultiRegisterOperation {
-            device: self.device,
-            start_address: self.start_address,
-            field_sets: self.field_sets.push(plan.value),
-            bit_sum: self.bit_sum + FS::SIZE_BITS,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<'d, D, FieldSets: FsSet>
-    MultiRegisterOperation<
-        'd,
-        D,
-        <D::Interface as device_driver::RegisterInterface>::AddressType,
-        FieldSets,
-        device_driver::RO,
-    >
-where
-    D: Device,
-    D::Interface: device_driver::RegisterInterface,
-{
-    #[inline]
-    pub fn execute(
-        mut self,
-    ) -> Result<FieldSets::Value, <D::Interface as device_driver::RegisterInterface>::Error> {
-        let data = self.field_sets.as_slice_mut();
-        self.device
-            .interface()
-            .read_register(self.start_address.unwrap(), self.bit_sum, data)?;
-        Ok(self.field_sets.to_value())
-    }
-}
-
-impl<'d, D, FieldSets: FsSet>
-    MultiRegisterOperation<
-        'd,
-        D,
-        <D::Interface as device_driver::RegisterInterface>::AddressType,
-        FieldSets,
-        device_driver::WO,
-    >
-where
-    D: Device,
-    D::Interface: device_driver::RegisterInterface,
-{
-    #[inline]
-    pub fn execute(
-        mut self,
-    ) -> Result<FieldSets::Value, <D::Interface as device_driver::RegisterInterface>::Error> {
-        let data = self.field_sets.as_slice_mut();
-        self.device
-            .interface()
-            .write_register(self.start_address.unwrap(), self.bit_sum, data)?;
-        Ok(self.field_sets.to_value())
-    }
-}
-
-impl<'d, D, FieldSets: FsSet>
-    MultiRegisterOperation<
-        'd,
-        D,
-        <D::Interface as device_driver::RegisterInterface>::AddressType,
-        FieldSets,
-        device_driver::RW,
-    >
-where
-    D: Device,
-    D::Interface: device_driver::RegisterInterface,
-{
-    #[inline]
-    pub fn execute<R>(
-        mut self,
-        f: impl FnOnce(FieldSets::ValueMut<'_>) -> R,
-    ) -> Result<R, <D::Interface as device_driver::RegisterInterface>::Error> {
-        self.device.interface().read_register(
-            self.start_address.unwrap(),
-            self.bit_sum,
-            self.field_sets.as_slice_mut(),
-        )?;
-
-        let returned = f(self.field_sets.as_value_mut());
-
-        self.device.interface().write_register(
-            self.start_address.unwrap(),
-            self.bit_sum,
-            self.field_sets.as_slice_mut(),
-        )?;
-
-        Ok(returned)
-    }
-}
-
-pub trait Device {
-    type Interface;
-    type AddressType;
-
-    fn interface(&mut self) -> &mut Self::Interface;
-
-    fn multi_read(
-        &mut self,
-    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::RO>
-    where
-        Self: Sized,
-    {
-        MultiRegisterOperation {
-            device: self,
-            start_address: None,
-            field_sets: (),
-            bit_sum: 0,
-            _phantom: PhantomData,
-        }
-    }
-
-    fn multi_write(
-        &mut self,
-    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::WO>
-    where
-        Self: Sized,
-    {
-        MultiRegisterOperation {
-            device: self,
-            start_address: None,
-            field_sets: (),
-            bit_sum: 0,
-            _phantom: PhantomData,
-        }
-    }
-
-    fn multi_modify(
-        &mut self,
-    ) -> MultiRegisterOperation<'_, Self, Self::AddressType, (), device_driver::RW>
-    where
-        Self: Sized,
-    {
-        MultiRegisterOperation {
-            device: self,
-            start_address: None,
-            field_sets: (),
-            bit_sum: 0,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<I> Device for MyTestDevice<I> {
-    type Interface = I;
-    type AddressType = u8;
-
-    fn interface(&mut self) -> &mut Self::Interface {
-        self.interface()
-    }
-}
 
 #[test]
 fn test_basic_read_modify_write() {

--- a/device-driver/tests/multi-register.rs
+++ b/device-driver/tests/multi-register.rs
@@ -1,0 +1,130 @@
+use device_driver::RegisterInterface;
+
+pub struct DeviceInterface {
+    device_memory: [u8; 128],
+}
+
+impl Default for DeviceInterface {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceInterface {
+    pub const fn new() -> Self {
+        Self {
+            device_memory: [0; 128],
+        }
+    }
+}
+
+impl RegisterInterface for DeviceInterface {
+    type Error = ();
+    type AddressType = u8;
+
+    fn write_register(
+        &mut self,
+        address: Self::AddressType,
+        _size_bits: u32,
+        data: &[u8],
+    ) -> Result<(), Self::Error> {
+        self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
+
+        Ok(())
+    }
+
+    fn read_register(
+        &mut self,
+        address: Self::AddressType,
+        _size_bits: u32,
+        data: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
+        Ok(())
+    }
+}
+
+device_driver::create_device!(
+    kdl: "
+        device MyTestDevice {
+            byte-order LE
+            register-address-type u8
+
+            register Foo {
+                address 0
+                reset-value 0xFFFFFF
+                fields size-bits=24 {
+                    (bool)value0 @0
+                    (uint)value1 @15:1
+                    (int)value2 @23:17
+                }
+            }
+
+            register Bar {
+                address 3
+                repeat count=8 stride=1
+                fields size-bits=8 {
+                    (int)value @7:0
+                }
+            }
+        }
+    "
+);
+
+#[test]
+fn multi_test() {
+    use device_driver::Block;
+    let mut device = MyTestDevice::new(DeviceInterface::new());
+
+    device
+        .multi_write()
+        .with(|d| d.bar(0).plan_with_zero())
+        .with(|d| d.foo().plan())
+        .execute(|(bar, _foo)| {
+            bar.set_value(42);
+        })
+        .unwrap();
+
+    let multi = device
+        .multi_read()
+        // TODO: Allow reading multiple. This would return a [Bar;N] that can also impl FieldSet.
+        // Maybe N is a const generic on foo_repeated with default 1?
+        // We'll also need a check whether it's allowed by the device rules. That's probably an assert.
+        .with(|d| d.bar(0).plan())
+        .with(|d| d.foo().plan())
+        .execute()
+        .unwrap();
+
+    assert_eq!(
+        multi,
+        (
+            BarFieldSet::from([42]),
+            FooFieldSet::from([0xFF, 0xFF, 0xFF])
+        )
+    );
+
+    device
+        .multi_modify()
+        .with(|d| d.bar(0).plan())
+        .with(|d| d.foo().plan())
+        .execute(|(bar, foo)| {
+            bar.set_value(-5);
+            foo.set_value_0(false);
+        })
+        .unwrap();
+
+    let multi = device
+        .multi_read()
+        .with(|d| d.bar(0).plan())
+        .with(|d| d.foo().plan())
+        .execute()
+        .unwrap();
+
+    assert_eq!(
+        multi,
+        (
+            BarFieldSet::from([-5i8 as u8]),
+            FooFieldSet::from([0xFE, 0xFF, 0xFF])
+        )
+    );
+}

--- a/device-driver/tests/multi-register.rs
+++ b/device-driver/tests/multi-register.rs
@@ -78,7 +78,7 @@ fn multi_test() {
 
     device
         .multi_write()
-        .with(|d| d.bar(0).plan_with_zero())
+        .with(|d| d.bar().plan_with_zero_at(0))
         .with(|d| d.foo().plan())
         .execute(|(bar, _foo)| {
             bar.set_value(42);
@@ -90,7 +90,7 @@ fn multi_test() {
         // TODO: Allow reading multiple. This would return a [Bar;N] that can also impl FieldSet.
         // Maybe N is a const generic on foo_repeated with default 1?
         // We'll also need a check whether it's allowed by the device rules. That's probably an assert.
-        .with(|d| d.bar(0).plan())
+        .with(|d| d.bar().plan_at(0))
         .with(|d| d.foo().plan())
         .execute()
         .unwrap();
@@ -105,7 +105,7 @@ fn multi_test() {
 
     device
         .multi_modify()
-        .with(|d| d.bar(0).plan())
+        .with(|d| d.bar().plan_at(0))
         .with(|d| d.foo().plan())
         .execute(|(bar, foo)| {
             bar.set_value(-5);
@@ -115,7 +115,7 @@ fn multi_test() {
 
     let multi = device
         .multi_read()
-        .with(|d| d.bar(0).plan())
+        .with(|d| d.bar().plan_at(0))
         .with(|d| d.foo().plan())
         .execute()
         .unwrap();

--- a/tests/cases/address_types/address_types.rs
+++ b/tests/cases/address_types/address_types.rs
@@ -12,18 +12,15 @@ fn main() {}
 /// Root block of the Device driver
 #[derive(Debug)]
 pub struct Device<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> Device<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     pub fn foo(
         &mut self,
@@ -34,6 +31,7 @@ impl<I> Device<I> {
         FooFieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::RegisterOperation::<
             '_,
@@ -44,6 +42,7 @@ impl<I> Device<I> {
         >::new(self.interface(), address as u16, FooFieldSet::new)
     }
     pub fn bar(&mut self) -> ::device_driver::CommandOperation<'_, I, i32, (), ()> {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::CommandOperation::<
             '_,
@@ -56,6 +55,7 @@ impl<I> Device<I> {
     pub fn quux(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, i8, ::device_driver::RW> {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::BufferOperation::<
             '_,
@@ -65,12 +65,22 @@ impl<I> Device<I> {
         >::new(self.interface(), address as i8)
     }
 }
+impl<I> ::device_driver::Block for Device<I> {
+    type Interface = I;
+    type RegisterAddressType = u16;
+    type CommandAddressType = i32;
+    type BufferAddressType = i8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
+unsafe impl ::device_driver::FieldSet for FooFieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/address_types/address_types.rs
+++ b/tests/cases/address_types/address_types.rs
@@ -69,12 +69,22 @@ pub struct FooFieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for FooFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooFieldSet {

--- a/tests/cases/address_types/address_types.rs
+++ b/tests/cases/address_types/address_types.rs
@@ -30,39 +30,27 @@ impl<I> Device<I> {
         u16,
         FooFieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u16,
-            FooFieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u16, FooFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u16,
+            FooFieldSet::new,
+        )
     }
-    pub fn bar(&mut self) -> ::device_driver::CommandOperation<'_, I, i32, (), ()> {
+    pub fn bar(&mut self) -> ::device_driver::CommandOperation<'_, I, i32, (), (), ()> {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::CommandOperation::<
-            '_,
-            I,
-            i32,
-            (),
-            (),
-        >::new(self.interface(), address as i32)
+        ::device_driver::CommandOperation::new(self.interface(), address as i32)
     }
     pub fn quux(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, i8, ::device_driver::RW> {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::BufferOperation::<
-            '_,
-            I,
-            i8,
-            ::device_driver::RW,
-        >::new(self.interface(), address as i8)
+        ::device_driver::BufferOperation::new(self.interface(), address as i8)
     }
 }
 impl<I> ::device_driver::Block for Device<I> {

--- a/tests/cases/basic_command/basic_command.rs
+++ b/tests/cases/basic_command/basic_command.rs
@@ -24,16 +24,10 @@ impl<I> Device<I> {
     }
     pub fn foo(
         &mut self,
-    ) -> ::device_driver::CommandOperation<'_, I, u8, FooFieldSetIn, ()> {
+    ) -> ::device_driver::CommandOperation<'_, I, u8, FooFieldSetIn, (), ()> {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::CommandOperation::<
-            '_,
-            I,
-            u8,
-            FooFieldSetIn,
-            (),
-        >::new(self.interface(), address as u8)
+        ::device_driver::CommandOperation::new(self.interface(), address as u8)
     }
 }
 impl<I> ::device_driver::Block for Device<I> {

--- a/tests/cases/basic_command/basic_command.rs
+++ b/tests/cases/basic_command/basic_command.rs
@@ -12,22 +12,20 @@ fn main() {}
 /// Root block of the Device driver
 #[derive(Debug)]
 pub struct Device<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> Device<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     pub fn foo(
         &mut self,
     ) -> ::device_driver::CommandOperation<'_, I, u8, FooFieldSetIn, ()> {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::CommandOperation::<
             '_,
@@ -38,12 +36,22 @@ impl<I> Device<I> {
         >::new(self.interface(), address as u8)
     }
 }
+impl<I> ::device_driver::Block for Device<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct FooFieldSetIn {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSetIn {
+unsafe impl ::device_driver::FieldSet for FooFieldSetIn {
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/basic_command/basic_command.rs
+++ b/tests/cases/basic_command/basic_command.rs
@@ -46,12 +46,22 @@ pub struct FooFieldSetIn {
     bits: [u8; 3],
 }
 unsafe impl ::device_driver::FieldSet for FooFieldSetIn {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooFieldSetIn {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooFieldSetIn {

--- a/tests/cases/basic_register/basic_register.rs
+++ b/tests/cases/basic_register/basic_register.rs
@@ -59,12 +59,22 @@ pub struct FooFieldSet {
     bits: [u8; 3],
 }
 unsafe impl ::device_driver::FieldSet for FooFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooFieldSet {

--- a/tests/cases/basic_register/basic_register.rs
+++ b/tests/cases/basic_register/basic_register.rs
@@ -32,16 +32,15 @@ impl<I> Device<I> {
         u8,
         FooFieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            FooFieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, FooFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            FooFieldSet::new,
+        )
     }
 }
 impl<I> ::device_driver::Block for Device<I> {

--- a/tests/cases/basic_register/basic_register.rs
+++ b/tests/cases/basic_register/basic_register.rs
@@ -14,18 +14,15 @@ fn main() {}
 /// Root block of the Device driver
 #[derive(Debug)]
 pub struct Device<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> Device<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     pub fn foo(
         &mut self,
@@ -36,6 +33,7 @@ impl<I> Device<I> {
         FooFieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::RegisterOperation::<
             '_,
@@ -46,12 +44,22 @@ impl<I> Device<I> {
         >::new(self.interface(), address as u8, FooFieldSet::new)
     }
 }
+impl<I> ::device_driver::Block for Device<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
+unsafe impl ::device_driver::FieldSet for FooFieldSet {
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/compile_time_explosion/compile_time_explosion.rs
+++ b/tests/cases/compile_time_explosion/compile_time_explosion.rs
@@ -12,18 +12,15 @@ fn main() {}
 /// Root block of the Device driver
 #[derive(Debug)]
 pub struct Device<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u32,
 }
 impl<I> Device<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     ///
     /// Valid index range: 0..100
@@ -37,6 +34,7 @@ impl<I> Device<I> {
         Foo0FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 0 + index as u32 * 1000
@@ -61,6 +59,7 @@ impl<I> Device<I> {
         Foo1FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 1 + index as u32 * 1000
@@ -85,6 +84,7 @@ impl<I> Device<I> {
         Foo2FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 2 + index as u32 * 1000
@@ -109,6 +109,7 @@ impl<I> Device<I> {
         Foo3FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 3 + index as u32 * 1000
@@ -133,6 +134,7 @@ impl<I> Device<I> {
         Foo4FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 4 + index as u32 * 1000
@@ -157,6 +159,7 @@ impl<I> Device<I> {
         Foo5FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 5 + index as u32 * 1000
@@ -181,6 +184,7 @@ impl<I> Device<I> {
         Foo6FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 6 + index as u32 * 1000
@@ -205,6 +209,7 @@ impl<I> Device<I> {
         Foo7FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 7 + index as u32 * 1000
@@ -229,6 +234,7 @@ impl<I> Device<I> {
         Foo8FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 8 + index as u32 * 1000
@@ -253,6 +259,7 @@ impl<I> Device<I> {
         Foo9FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 100);
             self.base_address + 9 + index as u32 * 1000
@@ -266,12 +273,22 @@ impl<I> Device<I> {
         >::new(self.interface(), address as u32, Foo9FieldSet::new)
     }
 }
+impl<I> ::device_driver::Block for Device<I> {
+    type Interface = I;
+    type RegisterAddressType = u32;
+    type CommandAddressType = u32;
+    type BufferAddressType = u32;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo0FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo0FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo0FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -359,11 +376,12 @@ impl core::ops::Not for Foo0FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo1FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo1FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo1FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -451,11 +469,12 @@ impl core::ops::Not for Foo1FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo2FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo2FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo2FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -543,11 +562,12 @@ impl core::ops::Not for Foo2FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo3FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo3FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo3FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -635,11 +655,12 @@ impl core::ops::Not for Foo3FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo4FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo4FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo4FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -727,11 +748,12 @@ impl core::ops::Not for Foo4FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo5FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo5FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo5FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -819,11 +841,12 @@ impl core::ops::Not for Foo5FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo6FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo6FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo6FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -911,11 +934,12 @@ impl core::ops::Not for Foo6FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo7FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo7FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo7FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1003,11 +1027,12 @@ impl core::ops::Not for Foo7FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo8FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo8FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo8FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1095,11 +1120,12 @@ impl core::ops::Not for Foo8FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foo9FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo9FieldSet {
+unsafe impl ::device_driver::FieldSet for Foo9FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/compile_time_explosion/compile_time_explosion.rs
+++ b/tests/cases/compile_time_explosion/compile_time_explosion.rs
@@ -239,12 +239,22 @@ pub struct Foo0FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo0FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo0FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo0FieldSet {
@@ -332,12 +342,22 @@ pub struct Foo1FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo1FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo1FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo1FieldSet {
@@ -425,12 +445,22 @@ pub struct Foo2FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo2FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo2FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo2FieldSet {
@@ -518,12 +548,22 @@ pub struct Foo3FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo3FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo3FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo3FieldSet {
@@ -611,12 +651,22 @@ pub struct Foo4FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo4FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo4FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo4FieldSet {
@@ -704,12 +754,22 @@ pub struct Foo5FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo5FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo5FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo5FieldSet {
@@ -797,12 +857,22 @@ pub struct Foo6FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo6FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo6FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo6FieldSet {
@@ -890,12 +960,22 @@ pub struct Foo7FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo7FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo7FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo7FieldSet {
@@ -983,12 +1063,22 @@ pub struct Foo8FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo8FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo8FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo8FieldSet {
@@ -1076,12 +1166,22 @@ pub struct Foo9FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foo9FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foo9FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foo9FieldSet {

--- a/tests/cases/compile_time_explosion/compile_time_explosion.rs
+++ b/tests/cases/compile_time_explosion/compile_time_explosion.rs
@@ -26,251 +26,201 @@ impl<I> Device<I> {
     /// Valid index range: 0..100
     pub fn foo_0(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo0FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 0 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo0FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo0FieldSet::new)
+        let address = self.base_address + 0;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo0FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_1(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo1FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 1 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo1FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo1FieldSet::new)
+        let address = self.base_address + 1;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo1FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_2(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo2FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 2 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo2FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo2FieldSet::new)
+        let address = self.base_address + 2;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo2FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_3(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo3FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 3 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo3FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo3FieldSet::new)
+        let address = self.base_address + 3;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo3FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_4(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo4FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 4 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo4FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo4FieldSet::new)
+        let address = self.base_address + 4;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo4FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_5(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo5FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 5 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo5FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo5FieldSet::new)
+        let address = self.base_address + 5;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo5FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_6(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo6FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 6 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo6FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo6FieldSet::new)
+        let address = self.base_address + 6;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo6FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_7(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo7FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 7 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo7FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo7FieldSet::new)
+        let address = self.base_address + 7;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo7FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_8(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo8FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 8 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo8FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo8FieldSet::new)
+        let address = self.base_address + 8;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo8FieldSet::new,
+        )
     }
     ///
     /// Valid index range: 0..100
     pub fn foo_9(
         &mut self,
-        index: usize,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u32,
         Foo9FieldSet,
         ::device_driver::RW,
+        ::device_driver::ArrayRepeat<100, 1000>,
     > {
         use ::device_driver::Block;
-        let address = {
-            assert!(index < 100);
-            self.base_address + 9 + index as u32 * 1000
-        };
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u32,
-            Foo9FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u32, Foo9FieldSet::new)
+        let address = self.base_address + 9;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u32,
+            Foo9FieldSet::new,
+        )
     }
 }
 impl<I> ::device_driver::Block for Device<I> {

--- a/tests/cases/description_string_escapes/description_string_escapes.rs
+++ b/tests/cases/description_string_escapes/description_string_escapes.rs
@@ -31,16 +31,15 @@ impl<I> Device<I> {
         u8,
         FooFieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            FooFieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, FooFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            FooFieldSet::new,
+        )
     }
 }
 impl<I> ::device_driver::Block for Device<I> {

--- a/tests/cases/description_string_escapes/description_string_escapes.rs
+++ b/tests/cases/description_string_escapes/description_string_escapes.rs
@@ -58,12 +58,22 @@ pub struct FooFieldSet {
     bits: [u8; 3],
 }
 unsafe impl ::device_driver::FieldSet for FooFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooFieldSet {

--- a/tests/cases/description_string_escapes/description_string_escapes.rs
+++ b/tests/cases/description_string_escapes/description_string_escapes.rs
@@ -12,18 +12,15 @@ fn main() {}
 /// Root block of the Device driver
 #[derive(Debug)]
 pub struct Device<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> Device<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     /// \\\\\\/\/\/\////\/\/;{}'"`'
     pub fn foo(
@@ -35,6 +32,7 @@ impl<I> Device<I> {
         FooFieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::RegisterOperation::<
             '_,
@@ -45,12 +43,22 @@ impl<I> Device<I> {
         >::new(self.interface(), address as u8, FooFieldSet::new)
     }
 }
+impl<I> ::device_driver::Block for Device<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
+unsafe impl ::device_driver::FieldSet for FooFieldSet {
     const SIZE_BITS: u32 = 24;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/device_definition_errors/device_definition_errors.rs
+++ b/tests/cases/device_definition_errors/device_definition_errors.rs
@@ -12,102 +12,138 @@ fn main() {}
 /// Root block of the FooD0 driver
 #[derive(Debug)]
 pub struct FooD0<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD0<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD0<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
 /// Root block of the FooD1 driver
 #[derive(Debug)]
 pub struct FooD1<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD1<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD1<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
 /// Root block of the FooD2 driver
 #[derive(Debug)]
 pub struct FooD2<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD2<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD2<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
 /// Root block of the FooD3 driver
 #[derive(Debug)]
 pub struct FooD3<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD3<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD3<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
 /// Root block of the FooD4 driver
 #[derive(Debug)]
 pub struct FooD4<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD4<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD4<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
 /// Root block of the FooD5 driver
 #[derive(Debug)]
 pub struct FooD5<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD5<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<I> ::device_driver::Block for FooD5<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         &mut self.interface
     }
 }
@@ -116,18 +152,15 @@ impl<I> FooD5<I> {
 /// Root block of the FooD6 driver
 #[derive(Debug)]
 pub struct FooD6<I> {
-    pub(crate) interface: I,
+    #[doc(hidden)]
+    interface: I,
     #[doc(hidden)]
     base_address: u8,
 }
 impl<I> FooD6<I> {
-    /// Create a new instance of the block based on device interface
+    /// Create a new instance of the device, using the interface
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
-    }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        &mut self.interface
     }
     pub fn foor_4(
         &mut self,
@@ -138,6 +171,7 @@ impl<I> FooD6<I> {
         Foor4FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::RegisterOperation::<
             '_,
@@ -156,6 +190,7 @@ impl<I> FooD6<I> {
         Foor5FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 1;
         ::device_driver::RegisterOperation::<
             '_,
@@ -174,6 +209,7 @@ impl<I> FooD6<I> {
         Foor6FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 2;
         ::device_driver::RegisterOperation::<
             '_,
@@ -192,6 +228,7 @@ impl<I> FooD6<I> {
         Foor7FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 3;
         ::device_driver::RegisterOperation::<
             '_,
@@ -211,6 +248,7 @@ impl<I> FooD6<I> {
         CustomFieldSetName,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 4;
         ::device_driver::RegisterOperation::<
             '_,
@@ -229,6 +267,7 @@ impl<I> FooD6<I> {
         Foor9FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 5;
         ::device_driver::RegisterOperation::<
             '_,
@@ -248,6 +287,7 @@ impl<I> FooD6<I> {
         Foor10FieldSet,
         ::device_driver::RW,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 6 + u16::from(index) as u8 * 2;
         ::device_driver::RegisterOperation::<
             '_,
@@ -266,6 +306,7 @@ impl<I> FooD6<I> {
         Fooc1FieldSetIn,
         Fooc1FieldSetOut,
     > {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::CommandOperation::<
             '_,
@@ -278,6 +319,7 @@ impl<I> FooD6<I> {
     pub fn foob_1(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RW> {
+        use ::device_driver::Block;
         let address = self.base_address + 0;
         ::device_driver::BufferOperation::<
             '_,
@@ -289,6 +331,7 @@ impl<I> FooD6<I> {
     pub fn foob_2(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RO> {
+        use ::device_driver::Block;
         let address = self.base_address + 2;
         ::device_driver::BufferOperation::<
             '_,
@@ -299,12 +342,14 @@ impl<I> FooD6<I> {
     }
     /// This is a block
     pub fn b_1(&mut self) -> B1<'_, I> {
+        use ::device_driver::Block;
         let address = self.base_address + 5;
         B1::<'_, I>::new(self.interface(), address)
     }
     ///
     /// Valid index range: 0..2
     pub fn b_2(&mut self, index: usize) -> B2<'_, I> {
+        use ::device_driver::Block;
         let address = {
             assert!(index < 2);
             self.base_address + 0 + index as u8 * 4
@@ -312,10 +357,20 @@ impl<I> FooD6<I> {
         B2::<'_, I>::new(self.interface(), address)
     }
 }
+impl<I> ::device_driver::Block for FooD6<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 /// This is a block
 #[derive(Debug)]
 pub struct B1<'i, I> {
-    pub(crate) interface: &'i mut I,
+    #[doc(hidden)]
+    interface: &'i mut I,
     #[doc(hidden)]
     base_address: u8,
 }
@@ -328,14 +383,20 @@ impl<'i, I> B1<'i, I> {
             base_address: base_address,
         }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
+}
+impl<'i, I> ::device_driver::Block for B1<'i, I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
         self.interface
     }
 }
 #[derive(Debug)]
 pub struct B2<'i, I> {
-    pub(crate) interface: &'i mut I,
+    #[doc(hidden)]
+    interface: &'i mut I,
     #[doc(hidden)]
     base_address: u8,
 }
@@ -348,13 +409,10 @@ impl<'i, I> B2<'i, I> {
             base_address: base_address,
         }
     }
-    /// A reference to the interface used to communicate with the device
-    pub(crate) fn interface(&mut self) -> &mut I {
-        self.interface
-    }
     pub fn b_2_foo(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RW> {
+        use ::device_driver::Block;
         let address = self.base_address + 42;
         ::device_driver::BufferOperation::<
             '_,
@@ -364,12 +422,22 @@ impl<'i, I> B2<'i, I> {
         >::new(self.interface(), address as u8)
     }
 }
+impl<'i, I> ::device_driver::Block for B2<'i, I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    fn interface(&mut self) -> &mut Self::Interface {
+        self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor4FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foor4FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor4FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -457,11 +525,12 @@ impl core::ops::Not for Foor4FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor5FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foor5FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor5FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -549,11 +618,12 @@ impl core::ops::Not for Foor5FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor6FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foor6FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor6FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -641,11 +711,12 @@ impl core::ops::Not for Foor6FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor7FieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foor7FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor7FieldSet {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -734,11 +805,12 @@ impl core::ops::Not for Foor7FieldSet {
 }
 /// This fieldset has a custom name
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct CustomFieldSetName {
     /// The internal bits
     bits: [u8; 1],
 }
-impl ::device_driver::FieldSet for CustomFieldSetName {
+unsafe impl ::device_driver::FieldSet for CustomFieldSetName {
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -880,11 +952,12 @@ impl core::ops::Not for CustomFieldSetName {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor9FieldSet {
     /// The internal bits
     bits: [u8; 1],
 }
-impl ::device_driver::FieldSet for Foor9FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor9FieldSet {
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1080,11 +1153,12 @@ impl core::ops::Not for Foor9FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Foor10FieldSet {
     /// The internal bits
     bits: [u8; 1],
 }
-impl ::device_driver::FieldSet for Foor10FieldSet {
+unsafe impl ::device_driver::FieldSet for Foor10FieldSet {
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1280,11 +1354,12 @@ impl core::ops::Not for Foor10FieldSet {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Fooc1FieldSetIn {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Fooc1FieldSetIn {
+unsafe impl ::device_driver::FieldSet for Fooc1FieldSetIn {
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1372,11 +1447,12 @@ impl core::ops::Not for Fooc1FieldSetIn {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Fooc1FieldSetOut {
     /// The internal bits
     bits: [u8; 1],
 }
-impl ::device_driver::FieldSet for Fooc1FieldSetOut {
+unsafe impl ::device_driver::FieldSet for Fooc1FieldSetOut {
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1491,11 +1567,12 @@ impl core::ops::Not for Fooc1FieldSetOut {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Fs1 {
     /// The internal bits
     bits: [u8; 2],
 }
-impl ::device_driver::FieldSet for Fs1 {
+unsafe impl ::device_driver::FieldSet for Fs1 {
     const SIZE_BITS: u32 = 16;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1610,11 +1687,12 @@ impl core::ops::Not for Fs1 {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Fs2 {
     /// The internal bits
     bits: [u8; 4],
 }
-impl ::device_driver::FieldSet for Fs2 {
+unsafe impl ::device_driver::FieldSet for Fs2 {
     const SIZE_BITS: u32 = 32;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
@@ -1756,11 +1834,12 @@ impl core::ops::Not for Fs2 {
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct Fs3 {
     /// The internal bits
     bits: [u8; 4],
 }
-impl ::device_driver::FieldSet for Fs3 {
+unsafe impl ::device_driver::FieldSet for Fs3 {
     const SIZE_BITS: u32 = 32;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits

--- a/tests/cases/device_definition_errors/device_definition_errors.rs
+++ b/tests/cases/device_definition_errors/device_definition_errors.rs
@@ -170,16 +170,15 @@ impl<I> FooD6<I> {
         u8,
         Foor4FieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor4FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor4FieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor4FieldSet::new,
+        )
     }
     pub fn foor_5(
         &mut self,
@@ -189,16 +188,15 @@ impl<I> FooD6<I> {
         u8,
         Foor5FieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 1;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor5FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor5FieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor5FieldSet::new,
+        )
     }
     pub fn foor_6(
         &mut self,
@@ -208,16 +206,15 @@ impl<I> FooD6<I> {
         u8,
         Foor6FieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 2;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor6FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor6FieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor6FieldSet::new,
+        )
     }
     pub fn foor_7(
         &mut self,
@@ -227,16 +224,15 @@ impl<I> FooD6<I> {
         u8,
         Foor7FieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 3;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor7FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor7FieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor7FieldSet::new,
+        )
     }
     /// Hello!
     pub fn foor_8(
@@ -247,16 +243,15 @@ impl<I> FooD6<I> {
         u8,
         CustomFieldSetName,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 4;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            CustomFieldSetName,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, CustomFieldSetName::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            CustomFieldSetName::new,
+        )
     }
     pub fn foor_9(
         &mut self,
@@ -266,36 +261,33 @@ impl<I> FooD6<I> {
         u8,
         Foor9FieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 5;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor9FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor9FieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor9FieldSet::new,
+        )
     }
     pub fn foor_10(
         &mut self,
-        index: Foo10E1,
     ) -> ::device_driver::RegisterOperation<
         '_,
         I,
         u8,
         Foor10FieldSet,
         ::device_driver::RW,
+        ::device_driver::EnumRepeat<Foo10E1, 2>,
     > {
         use ::device_driver::Block;
-        let address = self.base_address + 6 + u16::from(index) as u8 * 2;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            Foor10FieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, Foor10FieldSet::new)
+        let address = self.base_address + 6;
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            Foor10FieldSet::new,
+        )
     }
     pub fn fooc_1(
         &mut self,
@@ -305,40 +297,25 @@ impl<I> FooD6<I> {
         u8,
         Fooc1FieldSetIn,
         Fooc1FieldSetOut,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::CommandOperation::<
-            '_,
-            I,
-            u8,
-            Fooc1FieldSetIn,
-            Fooc1FieldSetOut,
-        >::new(self.interface(), address as u8)
+        ::device_driver::CommandOperation::new(self.interface(), address as u8)
     }
     pub fn foob_1(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RW> {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::BufferOperation::<
-            '_,
-            I,
-            u8,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8)
+        ::device_driver::BufferOperation::new(self.interface(), address as u8)
     }
     pub fn foob_2(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RO> {
         use ::device_driver::Block;
         let address = self.base_address + 2;
-        ::device_driver::BufferOperation::<
-            '_,
-            I,
-            u8,
-            ::device_driver::RO,
-        >::new(self.interface(), address as u8)
+        ::device_driver::BufferOperation::new(self.interface(), address as u8)
     }
     /// This is a block
     pub fn b_1(&mut self) -> B1<'_, I> {
@@ -414,12 +391,7 @@ impl<'i, I> B2<'i, I> {
     ) -> ::device_driver::BufferOperation<'_, I, u8, ::device_driver::RW> {
         use ::device_driver::Block;
         let address = self.base_address + 42;
-        ::device_driver::BufferOperation::<
-            '_,
-            I,
-            u8,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8)
+        ::device_driver::BufferOperation::new(self.interface(), address as u8)
     }
 }
 impl<'i, I> ::device_driver::Block for B2<'i, I> {

--- a/tests/cases/device_definition_errors/device_definition_errors.rs
+++ b/tests/cases/device_definition_errors/device_definition_errors.rs
@@ -410,12 +410,22 @@ pub struct Foor4FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foor4FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor4FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor4FieldSet {
@@ -503,12 +513,22 @@ pub struct Foor5FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foor5FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor5FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor5FieldSet {
@@ -596,12 +616,22 @@ pub struct Foor6FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foor6FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor6FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor6FieldSet {
@@ -689,12 +719,22 @@ pub struct Foor7FieldSet {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Foor7FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor7FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor7FieldSet {
@@ -783,12 +823,22 @@ pub struct CustomFieldSetName {
     bits: [u8; 1],
 }
 unsafe impl ::device_driver::FieldSet for CustomFieldSetName {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for CustomFieldSetName {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl CustomFieldSetName {
@@ -930,12 +980,22 @@ pub struct Foor9FieldSet {
     bits: [u8; 1],
 }
 unsafe impl ::device_driver::FieldSet for Foor9FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor9FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor9FieldSet {
@@ -1131,12 +1191,22 @@ pub struct Foor10FieldSet {
     bits: [u8; 1],
 }
 unsafe impl ::device_driver::FieldSet for Foor10FieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Foor10FieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Foor10FieldSet {
@@ -1332,12 +1402,22 @@ pub struct Fooc1FieldSetIn {
     bits: [u8; 0],
 }
 unsafe impl ::device_driver::FieldSet for Fooc1FieldSetIn {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 0;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Fooc1FieldSetIn {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Fooc1FieldSetIn {
@@ -1425,12 +1505,22 @@ pub struct Fooc1FieldSetOut {
     bits: [u8; 1],
 }
 unsafe impl ::device_driver::FieldSet for Fooc1FieldSetOut {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 8;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Fooc1FieldSetOut {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Fooc1FieldSetOut {
@@ -1545,12 +1635,22 @@ pub struct Fs1 {
     bits: [u8; 2],
 }
 unsafe impl ::device_driver::FieldSet for Fs1 {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 16;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Fs1 {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Fs1 {
@@ -1665,12 +1765,22 @@ pub struct Fs2 {
     bits: [u8; 4],
 }
 unsafe impl ::device_driver::FieldSet for Fs2 {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 32;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Fs2 {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Fs2 {
@@ -1812,12 +1922,22 @@ pub struct Fs3 {
     bits: [u8; 4],
 }
 unsafe impl ::device_driver::FieldSet for Fs3 {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 32;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for Fs3 {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl Fs3 {

--- a/tests/cases/device_definition_errors/diagnostics.txt
+++ b/tests/cases/device_definition_errors/diagnostics.txt
@@ -259,10 +259,10 @@
  63 │         address -1
  64 │         repeat count=18_446_744_073_709_551_616 stride=1
     ·                ────────────────┬───────────────
-    ·                                ╰── Value is out of the allowable range: 0..2^64
+    ·                                ╰── Value is out of the allowable range: 0..2^16
  65 │         allow-address-overlap #true
     ╰────
-  help: The count is encoded as a u64
+  help: The count is encoded as a u16
 
   error: Unexpected entries
     ╭─[cases/device_definition_errors/input.kdl:65:31]

--- a/tests/cases/device_definition_errors/stderr.rs.txt
+++ b/tests/cases/device_definition_errors/stderr.rs.txt
@@ -1,47 +1,47 @@
 error: The device driver input has errors that need to be solved!
-    --> device_definition_errors.rs:2161:1
+    --> device_definition_errors.rs:2281:1
      |
-2161 | compile_error!("The device driver input has errors that need to be solved!");
+2281 | compile_error!("The device driver input has errors that need to be solved!");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1683:28
+    --> device_definition_errors.rs:1793:28
      |
-1683 |     pub fn value(&self) -> Etype2 {
+1793 |     pub fn value(&self) -> Etype2 {
      |                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1696:37
+    --> device_definition_errors.rs:1806:37
      |
-1696 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1806 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                     ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1676 | impl<Etype3> Fs2 {
+1786 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1696:46
+    --> device_definition_errors.rs:1806:46
      |
-1696 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1806 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                              ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1676 | impl<Etype3> Fs2 {
+1786 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1709:40
+    --> device_definition_errors.rs:1819:40
      |
-1709 |     pub fn set_value(&mut self, value: Etype2) {
+1819 |     pub fn set_value(&mut self, value: Etype2) {
      |                                        ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1722:42
+    --> device_definition_errors.rs:1832:42
      |
-1722 |     pub fn set_value_2(&mut self, value: Etype3) {
+1832 |     pub fn set_value_2(&mut self, value: Etype3) {
      |                                          ^^^^^^ not found in this scope
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/cases/device_definition_errors/stderr.rs.txt
+++ b/tests/cases/device_definition_errors/stderr.rs.txt
@@ -1,47 +1,47 @@
 error: The device driver input has errors that need to be solved!
-    --> device_definition_errors.rs:2110:1
+    --> device_definition_errors.rs:2189:1
      |
-2110 | compile_error!("The device driver input has errors that need to be solved!");
+2189 | compile_error!("The device driver input has errors that need to be solved!");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1633:28
+    --> device_definition_errors.rs:1711:28
      |
-1633 |     pub fn value(&self) -> Etype2 {
+1711 |     pub fn value(&self) -> Etype2 {
      |                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1646:37
+    --> device_definition_errors.rs:1724:37
      |
-1646 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1724 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                     ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1626 | impl<Etype3> Fs2 {
+1704 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1646:46
+    --> device_definition_errors.rs:1724:46
      |
-1646 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1724 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                              ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1626 | impl<Etype3> Fs2 {
+1704 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1659:40
+    --> device_definition_errors.rs:1737:40
      |
-1659 |     pub fn set_value(&mut self, value: Etype2) {
+1737 |     pub fn set_value(&mut self, value: Etype2) {
      |                                        ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1672:42
+    --> device_definition_errors.rs:1750:42
      |
-1672 |     pub fn set_value_2(&mut self, value: Etype3) {
+1750 |     pub fn set_value_2(&mut self, value: Etype3) {
      |                                          ^^^^^^ not found in this scope
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/cases/device_definition_errors/stderr.rs.txt
+++ b/tests/cases/device_definition_errors/stderr.rs.txt
@@ -1,47 +1,47 @@
 error: The device driver input has errors that need to be solved!
-    --> device_definition_errors.rs:2189:1
+    --> device_definition_errors.rs:2161:1
      |
-2189 | compile_error!("The device driver input has errors that need to be solved!");
+2161 | compile_error!("The device driver input has errors that need to be solved!");
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1711:28
+    --> device_definition_errors.rs:1683:28
      |
-1711 |     pub fn value(&self) -> Etype2 {
+1683 |     pub fn value(&self) -> Etype2 {
      |                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1724:37
+    --> device_definition_errors.rs:1696:37
      |
-1724 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1696 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                     ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1704 | impl<Etype3> Fs2 {
+1676 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1724:46
+    --> device_definition_errors.rs:1696:46
      |
-1724 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
+1696 |     pub fn value_2(&self) -> Result<Etype3, <Etype3 as TryFrom<u8>>::Error> {
      |                                              ^^^^^^ not found in this scope
      |
 help: you might be missing a type parameter
      |
-1704 | impl<Etype3> Fs2 {
+1676 | impl<Etype3> Fs2 {
      |     ++++++++
 
 error[E0425]: cannot find type `Etype2` in this scope
-    --> device_definition_errors.rs:1737:40
+    --> device_definition_errors.rs:1709:40
      |
-1737 |     pub fn set_value(&mut self, value: Etype2) {
+1709 |     pub fn set_value(&mut self, value: Etype2) {
      |                                        ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `Etype3` in this scope
-    --> device_definition_errors.rs:1750:42
+    --> device_definition_errors.rs:1722:42
      |
-1750 |     pub fn set_value_2(&mut self, value: Etype3) {
+1722 |     pub fn set_value_2(&mut self, value: Etype3) {
      |                                          ^^^^^^ not found in this scope
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/cases/fieldset_access/fieldset_access.rs
+++ b/tests/cases/fieldset_access/fieldset_access.rs
@@ -93,12 +93,22 @@ pub struct FooRoFieldSet {
     bits: [u8; 8],
 }
 unsafe impl ::device_driver::FieldSet for FooRoFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 64;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooRoFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooRoFieldSet {
@@ -240,12 +250,22 @@ pub struct FooRwFieldSet {
     bits: [u8; 8],
 }
 unsafe impl ::device_driver::FieldSet for FooRwFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 64;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooRwFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooRwFieldSet {
@@ -387,12 +407,22 @@ pub struct FooWoFieldSet {
     bits: [u8; 8],
 }
 unsafe impl ::device_driver::FieldSet for FooWoFieldSet {
+    type Unpacked = Self;
     const SIZE_BITS: u32 = 64;
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
     fn get_inner_buffer_mut(&mut self) -> &mut [u8] {
         &mut self.bits
+    }
+    fn unpack(self) -> Self::Unpacked {
+        self
+    }
+}
+impl ::device_driver::UnpackedFieldSet for FooWoFieldSet {
+    type Packed = Self;
+    fn pack(self) -> Self::Packed {
+        self
     }
 }
 impl FooWoFieldSet {

--- a/tests/cases/fieldset_access/fieldset_access.rs
+++ b/tests/cases/fieldset_access/fieldset_access.rs
@@ -30,16 +30,15 @@ impl<I> Device<I> {
         u8,
         FooRoFieldSet,
         ::device_driver::RO,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 0;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            FooRoFieldSet,
-            ::device_driver::RO,
-        >::new(self.interface(), address as u8, FooRoFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            FooRoFieldSet::new,
+        )
     }
     pub fn foo_rw(
         &mut self,
@@ -49,16 +48,15 @@ impl<I> Device<I> {
         u8,
         FooRwFieldSet,
         ::device_driver::RW,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 1;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            FooRwFieldSet,
-            ::device_driver::RW,
-        >::new(self.interface(), address as u8, FooRwFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            FooRwFieldSet::new,
+        )
     }
     pub fn foo_wo(
         &mut self,
@@ -68,16 +66,15 @@ impl<I> Device<I> {
         u8,
         FooWoFieldSet,
         ::device_driver::WO,
+        (),
     > {
         use ::device_driver::Block;
         let address = self.base_address + 2;
-        ::device_driver::RegisterOperation::<
-            '_,
-            I,
-            u8,
-            FooWoFieldSet,
-            ::device_driver::WO,
-        >::new(self.interface(), address as u8, FooWoFieldSet::new)
+        ::device_driver::RegisterOperation::new(
+            self.interface(),
+            address as u8,
+            FooWoFieldSet::new,
+        )
     }
 }
 impl<I> ::device_driver::Block for Device<I> {


### PR DESCRIPTION
One of the biggest issues that remained unsolved in #38 was about the allocation of the fieldsets.
Const generics is not yet ready to allocate a buffer based on the sum of multiple generic consts.

So then the idea was that we could let the user allocate a buffer and then we'd allocate the fieldsets in there.
But that sucks. It'd require having non-owned variants of all fieldsets.

After thinking more I realized that was not the case. Fieldsets are just an array of bytes. If we make the fieldsets repr transparent, then we can split slices into `&mut [u8; N]` which we can then transmute into a mutable reference to the fieldset.

I still couldn't make this work. But then another realization hit. In memory, when two arrays are next to each other without padding inbetween, you can legally consider them 1 big array together.
So I started looking at the layout of tuples. The idea being that if the layout is guaranteed, you could cast a `(FooFieldSet, BarFieldSet)` to a u8 slice.

Sadly, tuples are `repr(rust)` and have no stable representation. But that's not the case for tuple structs. You can mark those `repr(C)`!
With the C ABI, the order is preserved. And all members are `align(1)` so no padding is added. Hence it's safe to get a u8 slice to it.
This means the allocation can be done by the compiler instead of by the user. :D

This leads to the following API: https://github.com/diondokter/device-driver/blob/37dddadabab1020338139dfa2db414fb7343a015/device-driver/tests/multi-register.rs#L79-L129

This PR does not support mixing reads and writes in one transaction. I've decided that's a different issue entirely (even if it's got overlap) and this PR doesn't preclude that functionality.

---

TODO:
- [x] Clean up. Move `Device` trait into main crate and change templates to impl it on devices and blocks. Consider renaming it to `Block`
- [x] Consider doing the `multi_write` the same way as `multi_modify` where there's one callback in the execute function instead of one per plan. This would allow not having to call the plan functions on the register operations. The only thing is that we still need to support the `write_with_zero` usecase, so there may still need to be a `.plan` function for that.
- [x] Add tests
- [ ] Add rules and checks
- [x] Add the ability to do multi-ops on repeated registers that use array types. See the todo comment in the code
- [ ] Implement fully packing the fieldsets (FieldSetArray & FsSet)
- [ ] Fix docs
- [ ] Check binary size impact and do some optimizations
- [ ] Add support for non-multiple-of-8-bits fieldsets. This requires packing and unpacking the bits. This is slow, but probably only for non-multiple-of-8-bits fieldsets. Or maybe it's too difficult and we don't support it.
- [ ] Make sure this is really the API we want. Also think about #183 since that's relevant.