### PR TITLE
Replace size-bits with size-bytes

### DIFF
--- a/compiler/dd-codegen/templates/rust/fieldset.rs.j2
+++ b/compiler/dd-codegen/templates/rust/fieldset.rs.j2
@@ -2,7 +2,7 @@
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct {{field_set.name.to_case(Case::Pascal)}} {
     /// The internal bits
-    bits: [u8; {{field_set.size_bytes()}}]
+    bits: [u8; {{field_set.size_bytes}}]
 }
 
 impl ::device_driver::Fieldset for {{field_set.name.to_case(Case::Pascal)}} {
@@ -21,7 +21,7 @@ impl ::device_driver::Fieldset for {{field_set.name.to_case(Case::Pascal)}} {
 impl {{field_set.name.to_case(Case::Pascal)}} {
     /// Create a new instance, loaded with all zeroes
     pub const fn new() -> Self {
-        Self { bits: [0; {{field_set.size_bytes()}}] }
+        Self { bits: [0; {{field_set.size_bytes}}] }
     }
 
     {% for field in field_set.fields %}
@@ -132,13 +132,13 @@ impl Default for {{field_set.name.to_case(Case::Pascal)}} {
     }
 }
 
-impl From<[u8; {{field_set.size_bytes()}}]> for {{field_set.name.to_case(Case::Pascal)}} {
-    fn from(bits: [u8; {{field_set.size_bytes()}}]) -> Self {
+impl From<[u8; {{field_set.size_bytes}}]> for {{field_set.name.to_case(Case::Pascal)}} {
+    fn from(bits: [u8; {{field_set.size_bytes}}]) -> Self {
         Self { bits }
     }
 }
 
-impl From<{{field_set.name.to_case(Case::Pascal)}}> for [u8; {{field_set.size_bytes()}}] {
+impl From<{{field_set.name.to_case(Case::Pascal)}}> for [u8; {{field_set.size_bytes}}] {
     fn from(val: {{field_set.name.to_case(Case::Pascal)}}) -> Self {
         val.bits
     }

--- a/compiler/dd-codegen/templates/rust/fieldset.rs.j2
+++ b/compiler/dd-codegen/templates/rust/fieldset.rs.j2
@@ -5,8 +5,11 @@ pub struct {{field_set.name.to_case(Case::Pascal)}} {
     bits: [u8; {{field_set.size_bytes()}}]
 }
 
-impl ::device_driver::FieldSet for {{field_set.name.to_case(Case::Pascal)}} {
-    const SIZE_BITS: u32 = {{field_set.size_bits}};
+impl ::device_driver::Fieldset for {{field_set.name.to_case(Case::Pascal)}} {
+    const METADATA: ::device_driver::FieldsetMetadata =
+        ::device_driver::FieldsetMetadata::new()
+            .with_byte_order(::device_driver::ByteOrder::{{field_set.byte_order}});
+            
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/compiler/dd-diagnostics/src/errors.rs
+++ b/compiler/dd-diagnostics/src/errors.rs
@@ -15,6 +15,7 @@ use itertools::Itertools;
 
 use crate::{Diagnostic, encode_ansi_url};
 
+#[derive(Debug)]
 pub struct IntegerFieldSizeTooBig {
     pub field_address: Span,
     pub base_type: Span,
@@ -63,6 +64,7 @@ impl Diagnostic for IntegerFieldSizeTooBig {
     }
 }
 
+#[derive(Debug)]
 pub struct DeviceNameNotPascal {
     pub device_name: Span,
     pub suggestion: String,
@@ -97,6 +99,7 @@ impl Diagnostic for DeviceNameNotPascal {
     }
 }
 
+#[derive(Debug)]
 pub struct DuplicateName {
     pub original: Span,
     pub original_value: Identifier,
@@ -139,6 +142,7 @@ impl Diagnostic for DuplicateName {
     }
 }
 
+#[derive(Debug)]
 pub struct EmptyEnum {
     pub enum_node: Span,
 }
@@ -165,6 +169,7 @@ impl Diagnostic for EmptyEnum {
     }
 }
 
+#[derive(Debug)]
 pub struct DuplicateVariantValue {
     pub duplicates: Vec<Span>,
     pub value: i128,
@@ -195,6 +200,7 @@ impl Diagnostic for DuplicateVariantValue {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumBadBasetype {
     pub enum_name: Span,
     pub base_type: Span,
@@ -236,6 +242,7 @@ impl Diagnostic for EnumBadBasetype {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumSizeBitsBiggerThanBaseType {
     pub enum_name: Span,
     pub base_type: Span,
@@ -275,6 +282,7 @@ impl Diagnostic for EnumSizeBitsBiggerThanBaseType {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumNoAutoBaseTypeSelected {
     pub enum_name: Span,
 }
@@ -304,6 +312,7 @@ impl Diagnostic for EnumNoAutoBaseTypeSelected {
     }
 }
 
+#[derive(Debug)]
 pub struct VariantValuesTooHigh {
     pub variant_names: Vec<Span>,
     pub enum_name: Span,
@@ -341,6 +350,7 @@ impl Diagnostic for VariantValuesTooHigh {
     }
 }
 
+#[derive(Debug)]
 pub struct VariantValuesTooLow {
     pub variant_names: Vec<Span>,
     pub enum_name: Span,
@@ -378,6 +388,7 @@ impl Diagnostic for VariantValuesTooLow {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumMultipleDefaults {
     pub enum_name: Span,
     pub variant_names: Vec<Span>,
@@ -422,6 +433,7 @@ impl Diagnostic for EnumMultipleDefaults {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumMultipleCatchalls {
     pub enum_name: Span,
     pub variant_names: Vec<Span>,
@@ -466,6 +478,7 @@ impl Diagnostic for EnumMultipleCatchalls {
     }
 }
 
+#[derive(Debug)]
 pub struct ReferencedObjectDoesNotExist {
     pub object_reference: Span,
 }
@@ -494,6 +507,7 @@ impl Diagnostic for ReferencedObjectDoesNotExist {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidConversionType {
     pub object_reference: Span,
     pub referenced_object: Span,
@@ -530,6 +544,7 @@ impl Diagnostic for InvalidConversionType {
     }
 }
 
+#[derive(Debug)]
 pub struct RepeatEnumWithCatchAll {
     pub repeat_enum: Span,
     pub enum_name: Span,
@@ -572,6 +587,7 @@ This is not possible with an enum containing a catch-all since it can take on an
     }
 }
 
+#[derive(Debug)]
 pub struct ExternInvalidBaseType {
     pub extern_name: Span,
     pub base_type: Option<Span>,
@@ -616,6 +632,7 @@ impl Diagnostic for ExternInvalidBaseType {
     }
 }
 
+#[derive(Debug)]
 pub struct DifferentBaseTypes {
     pub field: Span,
     pub field_base_type: BaseType,
@@ -665,6 +682,7 @@ impl Diagnostic for DifferentBaseTypes {
 }
 
 // TODO: Split in multiple error types
+#[derive(Debug)]
 pub struct InvalidInfallibleConversion {
     pub conversion: Span,
     pub context: Vec<Spanned<Cow<'static, str>>>,
@@ -705,6 +723,7 @@ impl Diagnostic for InvalidInfallibleConversion {
     }
 }
 
+#[derive(Debug)]
 pub struct UnspecifiedByteOrder {
     pub fieldset_name: Span,
 }
@@ -739,20 +758,21 @@ impl Diagnostic for UnspecifiedByteOrder {
     }
 }
 
-pub struct ResetValueTooBig {
+#[derive(Debug)]
+pub struct ResetValueIntTooBig {
     pub register_context: Span,
     pub reset_value: Span,
-    pub reset_value_size_bits: u32,
-    pub register_size_bits: u32,
+    pub reset_value_size_bytes: u32,
+    pub register_size_bytes: u32,
 }
 
-impl Diagnostic for ResetValueTooBig {
+impl Diagnostic for ResetValueIntTooBig {
     fn is_error(&self) -> bool {
         true
     }
 
     fn as_report<'a>(&'a self, source: &'a str, path: &'a str) -> Vec<Group<'a>> {
-        const INFO_TEXT: &str = "reset values must have the same size as their associated register. Integer-specified values are allowed to be smaller and will be 0-padded to the required size";
+        const INFO_TEXT: &str = "reset values cannot be bigger than their fieldset";
 
         [
             Level::ERROR.primary_title("reset value too big").element(
@@ -760,8 +780,8 @@ impl Diagnostic for ResetValueTooBig {
                     .path(path)
                     .annotation(AnnotationKind::Primary.span(self.reset_value.into()).label(
                         format!(
-                            "the reset value is specified with {} bits, but the register only has {}",
-                            self.reset_value_size_bits, self.register_size_bits
+                            "the reset value is specified with {} bytes, but the register only has {}",
+                            self.reset_value_size_bytes, self.register_size_bytes
                         ),
                     ))
                     .annotation(AnnotationKind::Visible.span(self.register_context.into())),
@@ -772,6 +792,7 @@ impl Diagnostic for ResetValueTooBig {
     }
 }
 
+#[derive(Debug)]
 pub struct ResetValueArrayWrongSize {
     pub register_context: Span,
     pub reset_value: Span,
@@ -807,6 +828,7 @@ impl Diagnostic for ResetValueArrayWrongSize {
     }
 }
 
+#[derive(Debug)]
 pub struct BoolFieldTooLarge {
     pub base_type: Option<Span>,
     pub address: Span,
@@ -852,12 +874,13 @@ impl Diagnostic for BoolFieldTooLarge {
     }
 }
 
+#[derive(Debug)]
 pub struct FieldAddressExceedsFieldsetSize {
     pub address: Span,
     pub max_field_end: i128,
     pub repeat_offset: Option<i128>,
-    pub fieldset_size_bits: Span,
-    pub fieldset_size: u32,
+    pub fieldset_size_span: Span,
+    pub fieldset_size_bits: u32,
 }
 
 impl FieldAddressExceedsFieldsetSize {
@@ -890,8 +913,11 @@ impl Diagnostic for FieldAddressExceedsFieldsetSize {
                         ))
                         .annotation(
                             AnnotationKind::Context
-                                .span(self.fieldset_size_bits.into())
-                                .label(format!("The fieldset is only {} bits", self.fieldset_size)),
+                                .span(self.fieldset_size_span.into())
+                                .label(format!(
+                                    "The fieldset is only {} bits",
+                                    self.fieldset_size_bits
+                                )),
                         ),
                 ),
             Group::with_title(Level::INFO.secondary_title(
@@ -902,6 +928,7 @@ impl Diagnostic for FieldAddressExceedsFieldsetSize {
     }
 }
 
+#[derive(Debug)]
 pub struct FieldAddressNegative {
     pub address: Span,
     pub min_field_start: i128,
@@ -947,6 +974,7 @@ impl Diagnostic for FieldAddressNegative {
     }
 }
 
+#[derive(Debug)]
 pub struct OverlappingFields {
     pub field_address_1: Span,
     pub repeat_offset_1: Option<i128>,
@@ -1019,6 +1047,7 @@ impl Diagnostic for OverlappingFields {
     }
 }
 
+#[derive(Debug)]
 pub struct AddressTypeUndefined {
     pub object_name: Span,
     pub device: Span,
@@ -1066,6 +1095,7 @@ impl Diagnostic for AddressTypeUndefined {
     }
 }
 
+#[derive(Debug)]
 pub struct AddressOutOfRange {
     pub object: Span,
     pub address: Span,
@@ -1129,6 +1159,7 @@ impl Diagnostic for AddressOutOfRange {
     }
 }
 
+#[derive(Debug)]
 pub struct AddressOverlap {
     pub address: i128,
     pub object_1: Span,
@@ -1207,6 +1238,7 @@ impl Diagnostic for AddressOverlap {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidIdentifier {
     pub error: identifier::Error,
     pub identifier: Span,
@@ -1268,6 +1300,7 @@ All other characters must be a unicode XID continue character.";
     }
 }
 
+#[derive(Debug)]
 pub struct ParsingError {
     pub reason: String,
     pub span: Span,
@@ -1290,6 +1323,7 @@ impl Diagnostic for ParsingError {
     }
 }
 
+#[derive(Debug)]
 pub struct UnknownNodeType {
     pub node_type: Span,
     pub allowed_node_types: Vec<NodeType>,
@@ -1315,6 +1349,7 @@ impl Diagnostic for UnknownNodeType {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidPropertyName {
     pub property: Span,
     pub node_type: Spanned<NodeType>,
@@ -1345,6 +1380,7 @@ impl Diagnostic for InvalidPropertyName {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidExpressionType {
     pub expression: Spanned<String>,
     pub node_type: Spanned<NodeType>,
@@ -1396,6 +1432,7 @@ impl Diagnostic for InvalidExpressionType {
     }
 }
 
+#[derive(Debug)]
 pub struct DuplicateProperty {
     pub original: Span,
     pub duplicate: Span,
@@ -1425,6 +1462,7 @@ impl Diagnostic for DuplicateProperty {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidNodeType {
     pub node_type: Span,
     pub parent_node_type: Option<Spanned<NodeType>>,
@@ -1466,6 +1504,7 @@ impl Diagnostic for InvalidNodeType {
     }
 }
 
+#[derive(Debug)]
 pub struct MissingRequiredProperty {
     pub node_type: Spanned<NodeType>,
     pub property_name: String,
@@ -1511,6 +1550,7 @@ impl Diagnostic for MissingRequiredProperty {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidSubnode {
     pub node_type: Spanned<NodeType>,
     pub subnode: Span,
@@ -1540,19 +1580,20 @@ impl Diagnostic for InvalidSubnode {
     }
 }
 
-pub struct SizeBitsTooLarge {
+#[derive(Debug)]
+pub struct SizeBytesTooLarge {
     pub value: Span,
     pub field_set: Span,
 }
 
-impl Diagnostic for SizeBitsTooLarge {
+impl Diagnostic for SizeBytesTooLarge {
     fn is_error(&self) -> bool {
         true
     }
 
     fn as_report<'a>(&'a self, source: &'a str, path: &'a str) -> Vec<Group<'a>> {
         [
-            Level::ERROR.primary_title("size-bits too large").element(
+            Level::ERROR.primary_title("size-bytes too large").element(
                 Snippet::source(source)
                     .path(path)
                     .annotation(AnnotationKind::Context.span(self.field_set.into()))
@@ -1564,7 +1605,7 @@ impl Diagnostic for SizeBitsTooLarge {
             ),
             Level::HELP
                 .secondary_title(
-                    "the maximum value of size-bits is 2^32-1. Keep the value below the limit",
+                    "the maximum value of size-bytes is 0x10_0000 (or 1MB). Keep the value below the limit",
                 )
                 .element(
                     Snippet::source(source)
@@ -1576,6 +1617,7 @@ impl Diagnostic for SizeBitsTooLarge {
     }
 }
 
+#[derive(Debug)]
 pub struct FieldAddressOutOfRange {
     pub field_address: Span,
 }
@@ -1599,6 +1641,7 @@ impl Diagnostic for FieldAddressOutOfRange {
     }
 }
 
+#[derive(Debug)]
 pub struct ResetValueNegative {
     pub reset_value: Span,
 }
@@ -1622,6 +1665,7 @@ impl Diagnostic for ResetValueNegative {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidShortProperty {
     pub property: Span,
     pub node_type: Spanned<NodeType>,
@@ -1668,6 +1712,7 @@ impl Diagnostic for InvalidShortProperty {
     }
 }
 
+#[derive(Debug)]
 pub struct FieldAddressWrongOrder {
     pub address: Span,
     pub end: i128,
@@ -1703,6 +1748,7 @@ impl Diagnostic for FieldAddressWrongOrder {
     }
 }
 
+#[derive(Debug)]
 pub struct IgnoredDocCommentOnProperty {
     pub doc_comments: Span,
     pub property: Span,
@@ -1730,6 +1776,7 @@ impl Diagnostic for IgnoredDocCommentOnProperty {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidTypeSpecifier {
     pub node_type: Spanned<NodeType>,
     pub type_specifier: Span,
@@ -1769,6 +1816,7 @@ impl Diagnostic for InvalidTypeSpecifier {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidTypeConversion {
     pub node_type: Spanned<NodeType>,
     pub type_conversion: Span,
@@ -1808,6 +1856,7 @@ impl Diagnostic for InvalidTypeConversion {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidFieldsetRef {
     pub reference: Span,
     pub pointee: Option<Span>,
@@ -1839,6 +1888,7 @@ impl Diagnostic for InvalidFieldsetRef {
     }
 }
 
+#[derive(Debug)]
 pub struct InvalidRepeat {
     pub repeat: Span,
     pub node_type: Spanned<NodeType>,

--- a/compiler/dd-diagnostics/src/lib.rs
+++ b/compiler/dd-diagnostics/src/lib.rs
@@ -3,12 +3,13 @@
     reason = "Something going on with the diagnostics derive"
 )]
 
-use std::{borrow::Cow, error::Error, fmt::Display, ops::Deref};
+use std::{borrow::Cow, error::Error, fmt::Debug, fmt::Display, ops::Deref};
 
 use annotate_snippets::{Group, Level, Renderer, renderer::DecorStyle};
 
 pub mod errors;
 
+#[derive(Debug)]
 pub struct Diagnostics {
     diagnostics: Vec<Box<dyn Diagnostic>>,
 }
@@ -167,7 +168,7 @@ fn strip_ansi_urls(text: &str) -> String {
     output
 }
 
-pub trait Diagnostic {
+pub trait Diagnostic: Debug {
     fn is_error(&self) -> bool;
     fn as_report<'a>(&'a self, source: &'a str, path: &'a str) -> Vec<Group<'a>>;
 }
@@ -269,6 +270,7 @@ impl<T, E: ErrorExt> ResultExt<T, E> for Result<T, E> {
     }
 }
 
+#[derive(Debug)]
 pub struct Message<'s> {
     string: Cow<'s, str>,
 }

--- a/compiler/dd-lir/src/lowering.rs
+++ b/compiler/dd-lir/src/lowering.rs
@@ -364,7 +364,7 @@ fn transform_field_set(manifest: &mir::Manifest, field_set: &mir::FieldSet) -> l
         byte_order: field_set
             .byte_order
             .expect("Byte order should never be none at this point after the MIR passes"),
-        size_bits: field_set.size_bits.value,
+        size_bytes: field_set.size_bytes.value,
         fields,
     }
 }

--- a/compiler/dd-lir/src/model.rs
+++ b/compiler/dd-lir/src/model.rs
@@ -69,14 +69,8 @@ pub struct FieldSet {
     pub description: String,
     pub name: Identifier,
     pub byte_order: ByteOrder,
-    pub size_bits: u32,
+    pub size_bytes: u32,
     pub fields: Vec<Field>,
-}
-
-impl FieldSet {
-    pub fn size_bytes(&self) -> u32 {
-        self.size_bits.div_ceil(8)
-    }
 }
 
 pub struct Field {

--- a/compiler/dd-mir/src/lowering.rs
+++ b/compiler/dd-mir/src/lowering.rs
@@ -26,7 +26,7 @@ use device_driver_diagnostics::{
         IgnoredDocCommentOnProperty, InvalidExpressionType, InvalidIdentifier, InvalidNodeType,
         InvalidPropertyName, InvalidRepeat, InvalidShortProperty, InvalidSubnode,
         InvalidTypeConversion, InvalidTypeSpecifier, MissingRequiredProperty, ResetValueNegative,
-        SizeBitsTooLarge, UnknownNodeType,
+        SizeBytesTooLarge, UnknownNodeType,
     },
 };
 use device_driver_parser::{Ast, Expression, Ident, Node, Property};
@@ -1027,7 +1027,7 @@ impl Shape for FieldSet {
     fn supported_properties() -> &'static [PropertyInfo<Self>] {
         static MAP: &[PropertyInfo<FieldSet>] = &[
             PropertyInfo {
-                name: PropertyName::Exact("size-bits"),
+                name: PropertyName::Exact("size-bytes"),
                 allowed_expression_types: Cow::Borrowed(&[Expression::Number(8)]),
                 multiple_allowed: false,
                 required: true,
@@ -1035,12 +1035,12 @@ impl Shape for FieldSet {
                 setter: |fs: &mut FieldSet, property, fs_node, diagnostics, _| match u32::try_from(
                     property.expression.as_number().unwrap(),
                 ) {
-                    Ok(size_bits) => {
-                        fs.size_bits = size_bits.with_span(property.expression.span);
+                    Ok(size_bytes) if size_bytes <= 0x10_0000 => {
+                        fs.size_bytes = size_bytes.with_span(property.expression.span);
                         false
                     }
-                    Err(_) => {
-                        diagnostics.add(SizeBitsTooLarge {
+                    _ => {
+                        diagnostics.add(SizeBytesTooLarge {
                             value: property.expression.span,
                             field_set: fs_node.span,
                         });

--- a/compiler/dd-mir/src/model.rs
+++ b/compiler/dd-mir/src/model.rs
@@ -528,12 +528,18 @@ pub struct Register {
 pub struct FieldSet {
     pub description: String,
     pub name: Spanned<Identifier>,
-    pub size_bits: Spanned<u32>,
+    pub size_bytes: Spanned<u32>,
     pub byte_order: Option<ByteOrder>,
     pub allow_bit_overlap: bool,
     pub fields: Vec<Field>,
     /// Span of the whole object
     pub span: Span,
+}
+
+impl FieldSet {
+    pub fn size_bits(&self) -> u32 {
+        self.size_bytes.value * 8
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]

--- a/compiler/dd-mir/src/passes/bit_ranges_validated.rs
+++ b/compiler/dd-mir/src/passes/bit_ranges_validated.rs
@@ -48,13 +48,13 @@ fn validate_len(
         let max_field_end = i128::from(field.field_address.end) + max_repeat_offset;
         let min_field_start = i128::from(field.field_address.start) + min_repeat_offset;
 
-        if max_field_end >= i128::from(field_set.size_bits.value) {
+        if max_field_end >= i128::from(field_set.size_bits()) {
             diagnostics.add(FieldAddressExceedsFieldsetSize {
                 address: field.field_address.span,
                 max_field_end,
                 repeat_offset: repeated.then_some(*max_repeat_offset),
-                fieldset_size: field_set.size_bits.value,
-                fieldset_size_bits: field_set.size_bits.span,
+                fieldset_size_bits: field_set.size_bits(),
+                fieldset_size_span: field_set.size_bytes.span,
             });
             removals.insert(field.id_with(field_set.id()));
         }
@@ -161,10 +161,10 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 1.with_dummy_span(),
                 fields: vec![Field {
                     name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 9 }.with_dummy_span(),
+                    field_address: AddressRange { start: 0, end: 7 }.with_dummy_span(),
                     ..Default::default()
                 }],
                 ..Default::default()
@@ -183,10 +183,10 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 1.with_dummy_span(),
                 fields: vec![Field {
                     name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 10 }.with_dummy_span(),
+                    field_address: AddressRange { start: 0, end: 8 }.with_dummy_span(),
                     ..Default::default()
                 }],
                 ..Default::default()
@@ -205,95 +205,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
-                fields: vec![Field {
-                    name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 9 }.with_dummy_span(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![Object::FieldSet(FieldSet {
-                name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
-                fields: vec![Field {
-                    name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 10 }.with_dummy_span(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(diagnostics.has_error());
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![Object::FieldSet(FieldSet {
-                name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
-                fields: vec![Field {
-                    name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 9 }.with_dummy_span(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![Object::FieldSet(FieldSet {
-                name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
-                fields: vec![Field {
-                    name: "my_field".into_with_dummy_span(),
-                    field_address: AddressRange { start: 0, end: 10 }.with_dummy_span(),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            })],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(diagnostics.has_error());
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![Object::FieldSet(FieldSet {
-                name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 1.with_dummy_span(),
                 fields: vec![Field {
                     name: "my_field".into_with_dummy_span(),
                     field_address: AddressRange { start: 0, end: 4 }.with_dummy_span(),
@@ -322,7 +234,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 fields: vec![
                     Field {
                         name: "my_field".into_with_dummy_span(),
@@ -351,7 +263,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 allow_bit_overlap: true,
                 fields: vec![
                     Field {
@@ -381,7 +293,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 fields: vec![
                     Field {
                         name: "my_field".into_with_dummy_span(),
@@ -411,7 +323,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyReg".into_with_dummy_span(),
-                size_bits: 10.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 fields: vec![
                     Field {
                         name: "my_field".into_with_dummy_span(),

--- a/compiler/dd-mir/src/passes/byte_order_specified.rs
+++ b/compiler/dd-mir/src/passes/byte_order_specified.rs
@@ -11,7 +11,7 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) {
                 fs.byte_order = config.byte_order;
             }
 
-            if fs.size_bits > 8 && fs.byte_order.is_none() {
+            if fs.size_bytes > 1 && fs.byte_order.is_none() {
                 diagnostics.add(UnspecifiedByteOrder {
                     fieldset_name: fs.name.span,
                 });
@@ -43,12 +43,12 @@ mod tests {
             objects: vec![
                 Object::FieldSet(FieldSet {
                     name: "MyRegister".into_with_dummy_span(),
-                    size_bits: 8.with_dummy_span(),
+                    size_bytes: 1.with_dummy_span(),
                     ..Default::default()
                 }),
                 Object::FieldSet(FieldSet {
                     name: "MyRegister2".into_with_dummy_span(),
-                    size_bits: 9.with_dummy_span(),
+                    size_bytes: 2.with_dummy_span(),
                     byte_order: Some(ByteOrder::LE),
                     ..Default::default()
                 }),
@@ -70,7 +70,7 @@ mod tests {
             device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyRegister".into_with_dummy_span(),
-                size_bits: 9.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 ..Default::default()
             })],
             span: Span::default(),
@@ -95,7 +95,7 @@ mod tests {
             device_config: global_config,
             objects: vec![Object::FieldSet(FieldSet {
                 name: "MyRegister".into_with_dummy_span(),
-                size_bits: 9.with_dummy_span(),
+                size_bytes: 2.with_dummy_span(),
                 ..Default::default()
             })],
             span: Span::default(),

--- a/compiler/dd-mir/src/passes/reset_values_converted.rs
+++ b/compiler/dd-mir/src/passes/reset_values_converted.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use device_driver_diagnostics::{
     Diagnostics,
-    errors::{ResetValueArrayWrongSize, ResetValueTooBig},
+    errors::{ResetValueArrayWrongSize, ResetValueIntTooBig},
 };
 
 /// Checks if the reset values of registers are valid.
@@ -32,7 +32,7 @@ pub fn run_pass(manifest: &mut Manifest, diagnostics: &mut Diagnostics) {
             if let Some(reset_value) = reg.reset_value.as_ref() {
                 let new_reset_value = convert_reset_value(
                     reset_value.clone(),
-                    target_field_set.size_bits.value,
+                    target_field_set.size_bytes.value,
                     target_field_set.byte_order.unwrap(),
                     diagnostics,
                     reg.name.span,
@@ -67,85 +67,55 @@ fn get_target_field_set<'m>(reg: &Register, manifest: &'m Manifest) -> &'m Field
 
 fn convert_reset_value(
     reset_value: Spanned<ResetValue>,
-    size_bits: u32,
+    size_bytes: u32,
     target_byte_order: ByteOrder,
     diagnostics: &mut Diagnostics,
     register_context: Span,
 ) -> Option<Spanned<ResetValue>> {
-    let target_byte_size = size_bits.div_ceil(8) as usize;
-
     match reset_value.value {
-        ResetValue::Integer(int) => {
-            // Assert int is a u128. The rest of the calculations bank on that
-            let _: u128 = int;
+        ResetValue::Integer(int) => match target_byte_order {
+            ByteOrder::LE => {
+                let int_bytes = int.to_le_bytes();
+                let (val, rest) = int_bytes.split_at(size_bytes as usize);
 
-            let used_bits = int.checked_ilog2().map(|log| log + 1).unwrap_or_default();
+                if rest.iter().any(|b| *b != 0) {
+                    diagnostics.add(ResetValueIntTooBig {
+                        reset_value: reset_value.span,
+                        reset_value_size_bytes: size_bytes
+                            + (rest.len() - rest.iter().rev().take_while(|b| **b == 0).count())
+                                as u32,
+                        register_size_bytes: size_bytes,
+                        register_context,
+                    });
+                    return None;
+                }
 
-            if used_bits > size_bits {
-                diagnostics.add(ResetValueTooBig {
-                    reset_value: reset_value.span,
-                    reset_value_size_bits: used_bits,
-                    register_size_bits: size_bits,
-                    register_context,
-                });
-                return None;
+                Some(ResetValue::Array(val.to_vec()).with_span(reset_value.span))
             }
+            ByteOrder::BE => {
+                let int_bytes = int.to_be_bytes();
+                let (rest, val) = int_bytes.split_at(int_bytes.len() - size_bytes as usize);
 
-            let mut array = vec![0; target_byte_size];
-            match target_byte_order {
-                ByteOrder::LE => {
-                    let num_bytes_used = target_byte_size.min(8);
-                    array[..num_bytes_used].copy_from_slice(&int.to_le_bytes()[..num_bytes_used]);
+                if rest.iter().any(|b| *b != 0) {
+                    diagnostics.add(ResetValueIntTooBig {
+                        reset_value: reset_value.span,
+                        reset_value_size_bytes: size_bytes
+                            + (rest.len() - rest.iter().take_while(|b| **b == 0).count()) as u32,
+                        register_size_bytes: size_bytes,
+                        register_context,
+                    });
+                    return None;
                 }
-                ByteOrder::BE => {
-                    let tmp = int.to_be_bytes();
-                    let tmp_slice = &tmp[tmp.len() - target_byte_size.min(8)..];
-                    array[target_byte_size - tmp_slice.len()..].copy_from_slice(tmp_slice);
-                }
-            };
 
-            convert_reset_value(
-                ResetValue::Array(array).with_span(reset_value.span),
-                size_bits,
-                target_byte_order,
-                diagnostics,
-                register_context,
-            )
-        }
+                Some(ResetValue::Array(val.to_vec()).with_span(reset_value.span))
+            }
+        },
         ResetValue::Array(array) => {
-            if array.len() != target_byte_size {
+            if array.len() != size_bytes as usize {
                 diagnostics.add(ResetValueArrayWrongSize {
                     reset_value: reset_value.span,
                     reset_value_size_bytes: array.len() as u32,
-                    register_size_bytes: target_byte_size as u32,
-                    register_context,
-                });
-                return None;
-            }
-
-            if array.is_empty() {
-                return Some(ResetValue::Array(array).with_span(reset_value.span));
-            }
-
-            let biggest_byte = match target_byte_order {
-                ByteOrder::LE => array.last().unwrap(),
-                ByteOrder::BE => array.first().unwrap(),
-            };
-
-            let used_bits = biggest_byte
-                .checked_ilog2()
-                .map(|log| log + 1)
-                .unwrap_or_default()
-                + (target_byte_size as u32 - 1) * 8;
-
-            // diagnostics.add(Message::new(format!("bit_order: {bit_order}, lsb0_biggest_byte: {lsb0_biggest_byte:#010b}, target_byte_size: {target_byte_size}, used bits: {used_bits}")));
-
-            // Check if the value is not too big
-            if used_bits > size_bits {
-                diagnostics.add(ResetValueTooBig {
-                    reset_value: reset_value.span,
-                    reset_value_size_bits: used_bits,
-                    register_size_bits: size_bits,
+                    register_size_bytes: size_bytes,
                     register_context,
                 });
                 return None;
@@ -158,381 +128,116 @@ fn convert_reset_value(
 
 #[cfg(test)]
 mod tests {
-    use device_driver_common::{identifier::IdentifierRef, span::Span};
-
-    use crate::model::{Device, DeviceConfig, FieldSet, Register};
-
     use super::*;
 
     #[test]
-    fn correct_sizes() {
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Integer(0x1F).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 5.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
+    fn integer_pass() {
+        // LE
         let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Integer(0x12_34).with_dummy_span(),
+                2,
+                ByteOrder::LE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            Some(ResetValue::Array(vec![0x34, 0x12]).with_dummy_span())
+        );
+        assert!(diagnostics.is_empty());
 
-        let end_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x1F]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 5.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        assert_eq!(start_mir, end_mir);
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x1F]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 5.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
+        // BE
         let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let end_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x1F]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 5.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        assert_eq!(start_mir, end_mir);
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: DeviceConfig {
-                byte_order: Some(ByteOrder::LE),
-                ..Default::default()
-            },
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Integer(0x423).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let end_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: DeviceConfig {
-                byte_order: Some(ByteOrder::LE),
-                ..Default::default()
-            },
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x23, 0x04]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        assert_eq!(start_mir, end_mir);
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x04, 0x23]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let end_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x04, 0x23]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        assert_eq!(start_mir, end_mir);
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x04, 0x23]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(!diagnostics.has_error());
-
-        let end_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x04, 0x23]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 11.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        assert_eq!(start_mir, end_mir);
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Integer(0x12_34).with_dummy_span(),
+                2,
+                ByteOrder::BE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            Some(ResetValue::Array(vec![0x12, 0x34]).with_dummy_span())
+        );
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
-    fn incorrect_sizes() {
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: DeviceConfig {
-                byte_order: Some(ByteOrder::LE),
-                ..Default::default()
-            },
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Integer(0x423).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 10.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
+    fn integer_fail() {
+        // LE
         let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Integer(0x12_34_56).with_dummy_span(),
+                1,
+                ByteOrder::LE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            None
+        );
         assert!(diagnostics.has_error());
+        println!("{diagnostics:?}");
 
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x04, 0x23]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 10.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
+        // BE
         let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Integer(0x12_34_56).with_dummy_span(),
+                1,
+                ByteOrder::BE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            None
+        );
         assert!(diagnostics.has_error());
-
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0x20, 0xC4]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 10.with_dummy_span(),
-                    byte_order: Some(ByteOrder::BE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
-
-        let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
-        assert!(diagnostics.has_error());
+        println!("{diagnostics:?}");
     }
 
     #[test]
-    fn wrong_num_bytes_array() {
-        let mut start_mir = Device {
-            description: String::new(),
-            name: "Device".into_with_dummy_span(),
-            device_config: Default::default(),
-            objects: vec![
-                Object::Register(Register {
-                    name: "Reg".into_with_dummy_span(),
-                    reset_value: Some(ResetValue::Array(vec![0, 0, 0]).with_dummy_span()),
-                    field_set_ref: IdentifierRef::new("fs".into()).with_dummy_span(),
-                    ..Default::default()
-                }),
-                Object::FieldSet(FieldSet {
-                    name: "fs".into_with_dummy_span(),
-                    size_bits: 32.with_dummy_span(),
-                    byte_order: Some(ByteOrder::LE),
-                    ..Default::default()
-                }),
-            ],
-            span: Span::default(),
-        }
-        .into();
+    fn array_pass() {
+        let mut diagnostics = Diagnostics::new();
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Array(vec![0x12, 0x34]).with_dummy_span(),
+                2,
+                ByteOrder::LE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            Some(ResetValue::Array(vec![0x12, 0x34]).with_dummy_span())
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn array_fail() {
+        let mut diagnostics = Diagnostics::new();
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Array(vec![0x12, 0x34, 0x56]).with_dummy_span(),
+                2,
+                ByteOrder::LE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            None
+        );
+        assert!(diagnostics.has_error());
+        println!("{diagnostics:?}");
 
         let mut diagnostics = Diagnostics::new();
-        run_pass(&mut start_mir, &mut diagnostics);
+        assert_eq!(
+            convert_reset_value(
+                ResetValue::Array(vec![0x12]).with_dummy_span(),
+                2,
+                ByteOrder::LE,
+                &mut diagnostics,
+                Span::empty()
+            ),
+            None
+        );
         assert!(diagnostics.has_error());
+        println!("{diagnostics:?}");
     }
 }

--- a/device-driver/src/command.rs
+++ b/device-driver/src/command.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::FieldSet;
+use crate::{Fieldset, FieldsetMetadata};
 
 /// A trait to represent the interface to the device.
 ///
@@ -19,10 +19,10 @@ pub trait CommandInterface {
     /// The slices are empty if the respective in or out fields are not specified.
     fn dispatch_command(
         &mut self,
+        _metadata_input: &FieldsetMetadata,
+        _metadata_output: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits_in: u32,
         input: &[u8],
-        size_bits_out: u32,
         output: &mut [u8],
     ) -> Result<(), Self::Error>;
 }
@@ -44,23 +44,23 @@ pub trait AsyncCommandInterface {
     /// The slices are empty if the respective in or out fields are not specified.
     async fn dispatch_command(
         &mut self,
+        _metadata_input: &FieldsetMetadata,
+        _metadata_output: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits_in: u32,
         input: &[u8],
-        size_bits_out: u32,
         output: &mut [u8],
     ) -> Result<(), Self::Error>;
 }
 
 /// Intermediate type for doing command operations
-pub struct CommandOperation<'i, Interface, AddressType: Copy, InFieldSet, OutFieldSet> {
+pub struct CommandOperation<'i, Interface, AddressType: Copy, InFieldset, OutFieldset> {
     interface: &'i mut Interface,
     address: AddressType,
-    _phantom: PhantomData<(InFieldSet, OutFieldSet)>,
+    _phantom: PhantomData<(InFieldset, OutFieldset)>,
 }
 
-impl<'i, Interface, AddressType: Copy, InFieldSet, OutFieldSet>
-    CommandOperation<'i, Interface, AddressType, InFieldSet, OutFieldSet>
+impl<'i, Interface, AddressType: Copy, InFieldset, OutFieldset>
+    CommandOperation<'i, Interface, AddressType, InFieldset, OutFieldset>
 {
     #[doc(hidden)]
     pub fn new(interface: &'i mut Interface, address: AddressType) -> Self {
@@ -79,47 +79,52 @@ where
 {
     /// Dispatch the command to the device
     pub fn dispatch(self) -> Result<(), Interface::Error> {
-        self.interface
-            .dispatch_command(self.address, 0, &[], 0, &mut [])
+        self.interface.dispatch_command(
+            &FieldsetMetadata::DEFAULT,
+            &FieldsetMetadata::DEFAULT,
+            self.address,
+            &[],
+            &mut [],
+        )
     }
 }
 
 /// Only input
-impl<Interface, AddressType: Copy, InFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, InFieldSet, ()>
+impl<Interface, AddressType: Copy, InFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, InFieldset, ()>
 where
     Interface: CommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
-    pub fn dispatch(self, f: impl FnOnce(&mut InFieldSet)) -> Result<(), Interface::Error> {
-        let mut in_fields = InFieldSet::default();
+    pub fn dispatch(self, f: impl FnOnce(&mut InFieldset)) -> Result<(), Interface::Error> {
+        let mut in_fields = InFieldset::default();
         f(&mut in_fields);
 
         self.interface.dispatch_command(
+            &InFieldset::METADATA,
+            &FieldsetMetadata::DEFAULT,
             self.address,
-            InFieldSet::SIZE_BITS,
             in_fields.get_inner_buffer(),
-            0,
             &mut [],
         )
     }
 }
 
 /// Only output
-impl<Interface, AddressType: Copy, OutFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, (), OutFieldSet>
+impl<Interface, AddressType: Copy, OutFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, (), OutFieldset>
 where
     Interface: CommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
-    pub fn dispatch(self) -> Result<OutFieldSet, Interface::Error> {
-        let mut out_fields = OutFieldSet::default();
+    pub fn dispatch(self) -> Result<OutFieldset, Interface::Error> {
+        let mut out_fields = OutFieldset::default();
 
         self.interface.dispatch_command(
+            &FieldsetMetadata::DEFAULT,
+            &OutFieldset::METADATA,
             self.address,
-            0,
             &[],
-            OutFieldSet::SIZE_BITS,
             out_fields.get_inner_buffer_mut(),
         )?;
 
@@ -128,26 +133,26 @@ where
 }
 
 /// Input and output
-impl<Interface, AddressType: Copy, InFieldSet: FieldSet, OutFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, InFieldSet, OutFieldSet>
+impl<Interface, AddressType: Copy, InFieldset: Fieldset, OutFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, InFieldset, OutFieldset>
 where
     Interface: CommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
     pub fn dispatch(
         self,
-        f: impl FnOnce(&mut InFieldSet),
-    ) -> Result<OutFieldSet, Interface::Error> {
-        let mut in_fields = InFieldSet::default();
+        f: impl FnOnce(&mut InFieldset),
+    ) -> Result<OutFieldset, Interface::Error> {
+        let mut in_fields = InFieldset::default();
         f(&mut in_fields);
 
-        let mut out_fields = OutFieldSet::default();
+        let mut out_fields = OutFieldset::default();
 
         self.interface.dispatch_command(
+            &InFieldset::METADATA,
+            &OutFieldset::METADATA,
             self.address,
-            InFieldSet::SIZE_BITS,
             in_fields.get_inner_buffer(),
-            OutFieldSet::SIZE_BITS,
             out_fields.get_inner_buffer_mut(),
         )?;
 
@@ -163,31 +168,37 @@ where
     /// Dispatch the command to the device
     pub async fn dispatch_async(self) -> Result<(), Interface::Error> {
         self.interface
-            .dispatch_command(self.address, 0, &[], 0, &mut [])
+            .dispatch_command(
+                &FieldsetMetadata::DEFAULT,
+                &FieldsetMetadata::DEFAULT,
+                self.address,
+                &[],
+                &mut [],
+            )
             .await
     }
 }
 
 /// Only input async
-impl<Interface, AddressType: Copy, InFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, InFieldSet, ()>
+impl<Interface, AddressType: Copy, InFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, InFieldset, ()>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
     pub async fn dispatch_async(
         self,
-        f: impl FnOnce(&mut InFieldSet),
+        f: impl FnOnce(&mut InFieldset),
     ) -> Result<(), Interface::Error> {
-        let mut in_fields = InFieldSet::default();
+        let mut in_fields = InFieldset::default();
         f(&mut in_fields);
 
         self.interface
             .dispatch_command(
+                &InFieldset::METADATA,
+                &FieldsetMetadata::DEFAULT,
                 self.address,
-                InFieldSet::SIZE_BITS,
                 in_fields.get_inner_buffer(),
-                0,
                 &mut [],
             )
             .await
@@ -195,21 +206,21 @@ where
 }
 
 /// Only output async
-impl<Interface, AddressType: Copy, OutFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, (), OutFieldSet>
+impl<Interface, AddressType: Copy, OutFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, (), OutFieldset>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
-    pub async fn dispatch_async(self) -> Result<OutFieldSet, Interface::Error> {
-        let mut out_fields = OutFieldSet::default();
+    pub async fn dispatch_async(self) -> Result<OutFieldset, Interface::Error> {
+        let mut out_fields = OutFieldset::default();
 
         self.interface
             .dispatch_command(
+                &FieldsetMetadata::DEFAULT,
+                &OutFieldset::METADATA,
                 self.address,
-                0,
                 &[],
-                OutFieldSet::SIZE_BITS,
                 out_fields.get_inner_buffer_mut(),
             )
             .await?;
@@ -219,27 +230,27 @@ where
 }
 
 /// Input and output async
-impl<Interface, AddressType: Copy, InFieldSet: FieldSet, OutFieldSet: FieldSet>
-    CommandOperation<'_, Interface, AddressType, InFieldSet, OutFieldSet>
+impl<Interface, AddressType: Copy, InFieldset: Fieldset, OutFieldset: Fieldset>
+    CommandOperation<'_, Interface, AddressType, InFieldset, OutFieldset>
 where
     Interface: AsyncCommandInterface<AddressType = AddressType>,
 {
     /// Dispatch the command to the device
     pub async fn dispatch_async(
         self,
-        f: impl FnOnce(&mut InFieldSet),
-    ) -> Result<OutFieldSet, Interface::Error> {
-        let mut in_fields = InFieldSet::default();
+        f: impl FnOnce(&mut InFieldset),
+    ) -> Result<OutFieldset, Interface::Error> {
+        let mut in_fields = InFieldset::default();
         f(&mut in_fields);
 
-        let mut out_fields = OutFieldSet::default();
+        let mut out_fields = OutFieldset::default();
 
         self.interface
             .dispatch_command(
+                &InFieldset::METADATA,
+                &OutFieldset::METADATA,
                 self.address,
-                InFieldSet::SIZE_BITS,
                 in_fields.get_inner_buffer(),
-                OutFieldSet::SIZE_BITS,
                 out_fields.get_inner_buffer_mut(),
             )
             .await?;

--- a/device-driver/src/lib.rs
+++ b/device-driver/src/lib.rs
@@ -22,12 +22,53 @@ pub mod ops;
 pub use device_driver_macros::*;
 
 #[doc(hidden)]
-pub trait FieldSet: Default {
-    /// The size of the field set in number of bits
-    const SIZE_BITS: u32;
+pub trait Fieldset: Default {
+    const METADATA: FieldsetMetadata;
 
     fn get_inner_buffer(&self) -> &[u8];
     fn get_inner_buffer_mut(&mut self) -> &mut [u8];
+}
+
+/// Metadata about fieldsets
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct FieldsetMetadata {
+    /// The byte order of the fieldset
+    pub byte_order: ByteOrder,
+}
+
+impl FieldsetMetadata {
+    /// A default that allow you to construct the metadata
+    pub const DEFAULT: Self = Self {
+        byte_order: ByteOrder::LE,
+    };
+
+    /// Create a new instance with the default value
+    pub const fn new() -> Self {
+        Self::DEFAULT
+    }
+
+    /// Set the byte order
+    pub const fn with_byte_order(self, byte_order: ByteOrder) -> Self {
+        Self { byte_order, ..self }
+    }
+}
+
+impl Default for FieldsetMetadata {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Value representing the byte order
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ByteOrder {
+    /// Little endian
+    LE,
+    /// Big endian
+    BE,
 }
 
 /// The error returned by the generated [`TryFrom`]s.
@@ -59,10 +100,6 @@ pub struct WO;
 pub struct RO;
 #[doc(hidden)]
 pub struct RW;
-#[doc(hidden)]
-pub struct RC;
-#[doc(hidden)]
-pub struct CO;
 
 #[doc(hidden)]
 pub trait ReadCapability {}

--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::{FieldSet, ReadCapability, WriteCapability};
+use crate::{Fieldset, FieldsetMetadata, ReadCapability, WriteCapability};
 
 /// A trait to represent the interface to the device.
 ///
@@ -14,16 +14,16 @@ pub trait RegisterInterface {
     /// Write the given data to the register located at the given address
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error>;
 
     /// Read the register located at the given address to the given data slice
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error>;
 }
@@ -40,36 +40,36 @@ pub trait AsyncRegisterInterface {
     /// Write the given data to the register located at the given address
     async fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error>;
 
     /// Read the register located at the given address to the given data slice
     async fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error>;
 }
 
 /// Object that performs actions on the device in the context of a register
-pub struct RegisterOperation<'i, Interface, AddressType: Copy, Register: FieldSet, Access> {
+pub struct RegisterOperation<'i, Interface, AddressType: Copy, RegisterFs: Fieldset, Access> {
     interface: &'i mut Interface,
     address: AddressType,
-    register_new_with_reset: fn() -> Register,
-    _phantom: PhantomData<(Register, Access)>,
+    register_new_with_reset: fn() -> RegisterFs,
+    _phantom: PhantomData<(RegisterFs, Access)>,
 }
 
-impl<'i, Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'i, Interface, AddressType, Register, Access>
+impl<'i, Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'i, Interface, AddressType, RegisterFs, Access>
 {
     #[doc(hidden)]
     pub fn new(
         interface: &'i mut Interface,
         address: AddressType,
-        register_new_with_reset: fn() -> Register,
+        register_new_with_reset: fn() -> RegisterFs,
     ) -> Self {
         Self {
             interface,
@@ -88,13 +88,13 @@ impl<'i, Interface, AddressType: Copy, Register: FieldSet, Access>
     }
 
     /// Get the register's reset value.
-    pub fn reset_value(&self) -> Register {
+    pub fn reset_value(&self) -> RegisterFs {
         (self.register_new_with_reset)()
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: RegisterInterface<AddressType = AddressType>,
     Access: WriteCapability,
@@ -103,13 +103,16 @@ where
     ///
     /// The closure is given the write object initialized to the reset value of the register.
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero`].
-    pub fn write<R>(&mut self, f: impl FnOnce(&mut Register) -> R) -> Result<R, Interface::Error> {
+    pub fn write<R>(
+        &mut self,
+        f: impl FnOnce(&mut RegisterFs) -> R,
+    ) -> Result<R, Interface::Error> {
         let mut register = (self.register_new_with_reset)();
         let returned = f(&mut register);
 
         self.interface.write_register(
+            &RegisterFs::METADATA,
             self.address,
-            Register::SIZE_BITS,
             register.get_inner_buffer(),
         )?;
         Ok(returned)
@@ -120,40 +123,40 @@ where
     /// The closure is given the write object initialized to all zero.
     pub fn write_with_zero<R>(
         &mut self,
-        f: impl FnOnce(&mut Register) -> R,
+        f: impl FnOnce(&mut RegisterFs) -> R,
     ) -> Result<R, Interface::Error> {
-        let mut register = Register::default();
+        let mut register = RegisterFs::default();
         let returned = f(&mut register);
         self.interface.write_register(
+            &RegisterFs::METADATA,
             self.address,
-            Register::SIZE_BITS,
             register.get_inner_buffer_mut(),
         )?;
         Ok(returned)
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: RegisterInterface<AddressType = AddressType>,
     Access: ReadCapability,
 {
     /// Read the register from the device
-    pub fn read(&mut self) -> Result<Register, Interface::Error> {
-        let mut register = Register::default();
+    pub fn read(&mut self) -> Result<RegisterFs, Interface::Error> {
+        let mut register = RegisterFs::default();
 
         self.interface.read_register(
+            &RegisterFs::METADATA,
             self.address,
-            Register::SIZE_BITS,
             register.get_inner_buffer_mut(),
         )?;
         Ok(register)
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: RegisterInterface<AddressType = AddressType>,
     Access: ReadCapability + WriteCapability,
@@ -162,20 +165,23 @@ where
     ///
     /// The register is read, the value is then passed to the closure for making changes.
     /// The result is then written back to the device.
-    pub fn modify<R>(&mut self, f: impl FnOnce(&mut Register) -> R) -> Result<R, Interface::Error> {
+    pub fn modify<R>(
+        &mut self,
+        f: impl FnOnce(&mut RegisterFs) -> R,
+    ) -> Result<R, Interface::Error> {
         let mut register = self.read()?;
         let returned = f(&mut register);
         self.interface.write_register(
+            &RegisterFs::METADATA,
             self.address,
-            Register::SIZE_BITS,
             register.get_inner_buffer_mut(),
         )?;
         Ok(returned)
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: WriteCapability,
@@ -186,15 +192,15 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero`].
     pub async fn write_async<R>(
         &mut self,
-        f: impl FnOnce(&mut Register) -> R,
+        f: impl FnOnce(&mut RegisterFs) -> R,
     ) -> Result<R, Interface::Error> {
         let mut register = (self.register_new_with_reset)();
         let returned = f(&mut register);
 
         self.interface
             .write_register(
+                &RegisterFs::METADATA,
                 self.address,
-                Register::SIZE_BITS,
                 register.get_inner_buffer(),
             )
             .await?;
@@ -206,14 +212,14 @@ where
     /// The closure is given the write object initialized to all zero.
     pub async fn write_with_zero_async<R>(
         &mut self,
-        f: impl FnOnce(&mut Register) -> R,
+        f: impl FnOnce(&mut RegisterFs) -> R,
     ) -> Result<R, Interface::Error> {
-        let mut register = Register::default();
+        let mut register = RegisterFs::default();
         let returned = f(&mut register);
         self.interface
             .write_register(
+                &RegisterFs::METADATA,
                 self.address,
-                Register::SIZE_BITS,
                 register.get_inner_buffer_mut(),
             )
             .await?;
@@ -221,20 +227,20 @@ where
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: ReadCapability,
 {
     /// Read the register from the device
-    pub async fn read_async(&mut self) -> Result<Register, Interface::Error> {
-        let mut register = Register::default();
+    pub async fn read_async(&mut self) -> Result<RegisterFs, Interface::Error> {
+        let mut register = RegisterFs::default();
 
         self.interface
             .read_register(
+                &RegisterFs::METADATA,
                 self.address,
-                Register::SIZE_BITS,
                 register.get_inner_buffer_mut(),
             )
             .await?;
@@ -242,8 +248,8 @@ where
     }
 }
 
-impl<Interface, AddressType: Copy, Register: FieldSet, Access>
-    RegisterOperation<'_, Interface, AddressType, Register, Access>
+impl<Interface, AddressType: Copy, RegisterFs: Fieldset, Access>
+    RegisterOperation<'_, Interface, AddressType, RegisterFs, Access>
 where
     Interface: AsyncRegisterInterface<AddressType = AddressType>,
     Access: ReadCapability + WriteCapability,
@@ -254,14 +260,14 @@ where
     /// The result is then written back to the device.
     pub async fn modify_async<R>(
         &mut self,
-        f: impl FnOnce(&mut Register) -> R,
+        f: impl FnOnce(&mut RegisterFs) -> R,
     ) -> Result<R, Interface::Error> {
         let mut register = self.read_async().await?;
         let returned = f(&mut register);
         self.interface
             .write_register(
+                &RegisterFs::METADATA,
                 self.address,
-                Register::SIZE_BITS,
                 register.get_inner_buffer(),
             )
             .await?;

--- a/device-driver/tests/basic-block.rs
+++ b/device-driver/tests/basic-block.rs
@@ -1,4 +1,4 @@
-use device_driver::RegisterInterface;
+use device_driver::{FieldsetMetadata, RegisterInterface};
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -24,8 +24,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        _size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
@@ -35,8 +35,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        _size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);

--- a/device-driver/tests/basic-block.rs
+++ b/device-driver/tests/basic-block.rs
@@ -57,7 +57,7 @@ device_driver::compile!(
                 register Foo {
                     address: 0,
                     fields: fieldset FooFields {
-                        size-bits: 24,
+                        size-bytes: 3,
 
                         /// This is a bool!
                         field value0 0 -> bool,

--- a/device-driver/tests/basic-command.rs
+++ b/device-driver/tests/basic-command.rs
@@ -39,7 +39,7 @@ device_driver::compile!(
             command Input {
                 address: 1,
                 fields-in: fieldset InputFieldsIn {
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     /// The value!
                     field val 15:0 -> uint
@@ -49,7 +49,7 @@ device_driver::compile!(
             command Output {
                 address: 2,
                 fields-out: fieldset OutputFieldsOut {
-                    size-bits: 8,
+                    size-bytes: 1,
 
                     /// The value!
                     field val 7:0 -> uint
@@ -59,13 +59,13 @@ device_driver::compile!(
             command InOut {
                 address: 3,
                 fields-in: fieldset InOutFieldsIn {
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     /// The value!
                     field val 15:0 -> uint,
                 },
                 fields-out: fieldset InOutFieldsOut {
-                    size-bits: 8,
+                    size-bytes: 1,
 
                     /// The value!
                     field val 7:0 -> uint

--- a/device-driver/tests/basic-command.rs
+++ b/device-driver/tests/basic-command.rs
@@ -1,4 +1,4 @@
-use device_driver::CommandInterface;
+use device_driver::{CommandInterface, FieldsetMetadata};
 
 pub struct DeviceInterface {
     last_command: u8,
@@ -11,10 +11,10 @@ impl CommandInterface for DeviceInterface {
 
     fn dispatch_command(
         &mut self,
+        _metadata_input: &FieldsetMetadata,
+        _metadata_output: &FieldsetMetadata,
         address: Self::AddressType,
-        _size_bits_in: u32,
         input: &[u8],
-        _size_bits_out: u32,
         output: &mut [u8],
     ) -> Result<(), Self::Error> {
         self.last_command = address;

--- a/device-driver/tests/basic-register-async.rs
+++ b/device-driver/tests/basic-register-async.rs
@@ -1,4 +1,4 @@
-use device_driver::AsyncRegisterInterface;
+use device_driver::{AsyncRegisterInterface, FieldsetMetadata};
 
 pub struct DeviceInterface;
 
@@ -8,8 +8,8 @@ impl AsyncRegisterInterface for DeviceInterface {
 
     async fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         _data: &[u8],
     ) -> Result<(), Self::Error> {
         unimplemented!()
@@ -17,8 +17,8 @@ impl AsyncRegisterInterface for DeviceInterface {
 
     async fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         _data: &mut [u8],
     ) -> Result<(), Self::Error> {
         unimplemented!()

--- a/device-driver/tests/basic-register-async.rs
+++ b/device-driver/tests/basic-register-async.rs
@@ -33,7 +33,7 @@ device_driver::compile!(
             register Foo {
                 address: 0,
                 fields: fieldset FooFields {
-                    size-bits: 8,
+                    size-bytes: 1,
                     field value0 0 -> bool
                 }
             }

--- a/device-driver/tests/basic-register-manifest.rs
+++ b/device-driver/tests/basic-register-manifest.rs
@@ -1,4 +1,4 @@
-use device_driver::RegisterInterface;
+use device_driver::{FieldsetMetadata, RegisterInterface};
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -24,11 +24,11 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        assert_eq!(data.len(), 3);
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
 
         Ok(())
@@ -36,11 +36,11 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        assert_eq!(data.len(), 3);
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
         Ok(())
     }

--- a/device-driver/tests/basic-register.ddsl
+++ b/device-driver/tests/basic-register.ddsl
@@ -6,7 +6,7 @@ device MyTestDevice {
     register Foo {
         address: 0,
         fields: fieldset FooFields {
-            size-bits: 24,
+            size-bytes: 3,
 
             /// This is a bool!
             field value0 0 -> bool,

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -1,4 +1,4 @@
-use device_driver::RegisterInterface;
+use device_driver::{FieldsetMetadata, RegisterInterface};
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -24,11 +24,11 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        assert_eq!(data.len(), 3);
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
 
         Ok(())
@@ -36,11 +36,11 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
-        assert_eq!(size_bits, 24);
+        assert_eq!(data.len(), 3);
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);
         Ok(())
     }

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -59,7 +59,7 @@ device_driver::compile!(
             register Foo {
                 address: 0,
                 fields: fieldset FooFields {
-                    size-bits: 24,
+                    size-bytes: 3,
 
                     /// This is a bool!
                     field value0 0 -> bool,

--- a/device-driver/tests/bit-ops.rs
+++ b/device-driver/tests/bit-ops.rs
@@ -11,7 +11,7 @@ device_driver::compile!(
                 reset: 0xFFFFFFFF,
 
                 fields: fieldset FooFieldSet {
-                    size-bits: 32,
+                    size-bytes: 4,
 
                     field value 31:0 -> uint
                 }

--- a/device-driver/tests/bit-ops.rs
+++ b/device-driver/tests/bit-ops.rs
@@ -1,4 +1,4 @@
-use device_driver::RegisterInterface;
+use device_driver::{FieldsetMetadata, RegisterInterface};
 
 device_driver::compile!(
     ddsl: "
@@ -28,8 +28,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         _data: &[u8],
     ) -> Result<(), Self::Error> {
         unimplemented!()
@@ -37,8 +37,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         _data: &mut [u8],
     ) -> Result<(), Self::Error> {
         unimplemented!()

--- a/device-driver/tests/docs-everywhere.rs
+++ b/device-driver/tests/docs-everywhere.rs
@@ -14,7 +14,7 @@ device_driver::compile!(
                 fields:
                     /// X
                     fieldset FooFields {
-                        size-bits: 8,
+                        size-bytes: 1,
                         /// X
                         field value0 0 -> bool
                     }
@@ -25,14 +25,14 @@ device_driver::compile!(
                 fields-in:
                     /// X
                     fieldset BarFieldsIn {
-                        size-bits: 8,
+                        size-bytes: 1,
                         /// X
                         field value0 0 -> bool
                     },
                 fields-out:
                     /// X
                     fieldset BarFieldsOut {
-                        size-bits: 8,
+                        size-bytes: 1,
                         /// X
                         field value0 0 -> bool
                     },

--- a/device-driver/tests/endianness-respected.rs
+++ b/device-driver/tests/endianness-respected.rs
@@ -41,7 +41,7 @@ device_driver::compile!(
 
                 fields: fieldset FooLEFields {
                     byte-order: LE,
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     field val 15:0 -> uint
                 }
@@ -53,7 +53,7 @@ device_driver::compile!(
 
                 fields: fieldset FooLEArrayFields {
                     byte-order: LE,
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     field val 15:0 -> uint
                 }
@@ -65,7 +65,7 @@ device_driver::compile!(
 
                 fields: fieldset FooBEFields {
                     byte-order: BE,
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     field val 15:0 -> uint
                 }
@@ -77,7 +77,7 @@ device_driver::compile!(
 
                 fields: fieldset FooBEArrayFields {
                     byte-order: BE,
-                    size-bits: 16,
+                    size-bytes: 2,
 
                     field val 15:0 -> uint
                 }

--- a/device-driver/tests/endianness-respected.rs
+++ b/device-driver/tests/endianness-respected.rs
@@ -1,4 +1,4 @@
-use device_driver::RegisterInterface;
+use device_driver::{FieldsetMetadata, RegisterInterface};
 
 pub struct DeviceInterface;
 
@@ -8,8 +8,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
         // Assert data is little endian
@@ -20,8 +20,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         _address: Self::AddressType,
-        _size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
         data.copy_from_slice(&[0x32, 0x12]);

--- a/device-driver/tests/register-access.rs
+++ b/device-driver/tests/register-access.rs
@@ -8,7 +8,7 @@ device_driver::compile!(
             register Foo {
                 address: 0,
                 fields: fieldset FooFields {
-                    size-bits: 8,
+                    size-bytes: 1,
 
                     /// X
                     field value0 0 -> bool,
@@ -18,7 +18,7 @@ device_driver::compile!(
                 access: RO,
                 address: 1,
                 fields: fieldset BarFields {
-                    size-bits: 8,
+                    size-bytes: 1,
 
                     /// X
                     field value0 WO 0 -> bool,
@@ -28,7 +28,7 @@ device_driver::compile!(
                 access: WO,
                 address: 2,
                 fields: fieldset BazFields {
-                    size-bits: 8,
+                    size-bytes: 1,
 
                     /// X
                     field value0 0 -> bool,

--- a/device-driver/tests/type-conversions.rs
+++ b/device-driver/tests/type-conversions.rs
@@ -52,7 +52,7 @@ device_driver::compile!(
             register Foo {
                 address: 0,
                 fields: fieldset FooFields {
-                    size-bits: 64,
+                    size-bytes: 8,
 
                     /// Try needed since [MyTryEnum] doesn't impl [From]
                     field convert_custom_try 1:0 -> uint as try MyTryEnum,

--- a/device-driver/tests/type-conversions.rs
+++ b/device-driver/tests/type-conversions.rs
@@ -1,4 +1,4 @@
-use device_driver::{ConversionError, RegisterInterface};
+use device_driver::{ConversionError, FieldsetMetadata, RegisterInterface};
 
 pub struct DeviceInterface {
     device_memory: [u8; 128],
@@ -24,8 +24,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn write_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        _size_bits: u32,
         data: &[u8],
     ) -> Result<(), Self::Error> {
         self.device_memory[address as usize..][..data.len()].copy_from_slice(data);
@@ -35,8 +35,8 @@ impl RegisterInterface for DeviceInterface {
 
     fn read_register(
         &mut self,
+        _metadata: &FieldsetMetadata,
         address: Self::AddressType,
-        _size_bits: u32,
         data: &mut [u8],
     ) -> Result<(), Self::Error> {
         data.copy_from_slice(&self.device_memory[address as usize..][..data.len()]);

--- a/tests/ui/cases/address_types/address_types.rs
+++ b/tests/ui/cases/address_types/address_types.rs
@@ -70,8 +70,9 @@ pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
-    const SIZE_BITS: u32 = 0;
+impl ::device_driver::Fieldset for FooFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/address_types/input.ddsl
+++ b/tests/ui/cases/address_types/input.ddsl
@@ -7,7 +7,7 @@ device Device {
     register Foo {
         address: 0,
         fields: fieldset FooFieldSet {
-            size-bits: 0
+            size-bytes: 0
         }
     },
     command Bar {

--- a/tests/ui/cases/basic_command/basic_command.rs
+++ b/tests/ui/cases/basic_command/basic_command.rs
@@ -43,8 +43,9 @@ pub struct FooFieldSetIn {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSetIn {
-    const SIZE_BITS: u32 = 24;
+impl ::device_driver::Fieldset for FooFieldSetIn {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/basic_command/input.ddsl
+++ b/tests/ui/cases/basic_command/input.ddsl
@@ -6,7 +6,7 @@ device Device {
         address: 0,
 
         fields-in: fieldset FooFieldSetIn {
-            size-bits: 24,
+            size-bytes: 3,
 
             field value 23:0 -> uint
         }

--- a/tests/ui/cases/basic_register/basic_register.rs
+++ b/tests/ui/cases/basic_register/basic_register.rs
@@ -51,8 +51,9 @@ pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
-    const SIZE_BITS: u32 = 24;
+impl ::device_driver::Fieldset for FooFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/basic_register/input.ddsl
+++ b/tests/ui/cases/basic_register/input.ddsl
@@ -7,7 +7,7 @@ device Device {
         address: 0,
 
         fields: fieldset FooFieldSet {
-            size-bits: 24,
+            size-bytes: 3,
 
             field value 23:0 -> uint
         }

--- a/tests/ui/cases/compile_time_explosion/compile_time_explosion.rs
+++ b/tests/ui/cases/compile_time_explosion/compile_time_explosion.rs
@@ -211,8 +211,9 @@ pub struct Foo {
     /// The internal bits
     bits: [u8; 0],
 }
-impl ::device_driver::FieldSet for Foo {
-    const SIZE_BITS: u32 = 0;
+impl ::device_driver::Fieldset for Foo {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/compile_time_explosion/input.ddsl
+++ b/tests/ui/cases/compile_time_explosion/input.ddsl
@@ -3,7 +3,7 @@ device Device {
     register-address-type: u32,
 
     fieldset Foo {
-        size-bits: 0
+        size-bytes: 0
     },
 
     register Foo0[100*1000] {

--- a/tests/ui/cases/description_string_escapes/description_string_escapes.rs
+++ b/tests/ui/cases/description_string_escapes/description_string_escapes.rs
@@ -50,8 +50,9 @@ pub struct FooFieldSet {
     /// The internal bits
     bits: [u8; 3],
 }
-impl ::device_driver::FieldSet for FooFieldSet {
-    const SIZE_BITS: u32 = 24;
+impl ::device_driver::Fieldset for FooFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/description_string_escapes/input.ddsl
+++ b/tests/ui/cases/description_string_escapes/input.ddsl
@@ -5,7 +5,7 @@ device Device {
     register Foo {
         address: 0,
         fields: fieldset FooFieldSet {
-            size-bits: 24,
+            size-bytes: 3,
             /// \\\"#{
             /// %@&\n
             field value 23:0 -> uint

--- a/tests/ui/cases/fieldset_access/fieldset_access.rs
+++ b/tests/ui/cases/fieldset_access/fieldset_access.rs
@@ -85,8 +85,9 @@ pub struct FooWoFieldSet {
     /// The internal bits
     bits: [u8; 8],
 }
-impl ::device_driver::FieldSet for FooWoFieldSet {
-    const SIZE_BITS: u32 = 64;
+impl ::device_driver::Fieldset for FooWoFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
@@ -240,8 +241,9 @@ pub struct FooRwFieldSet {
     /// The internal bits
     bits: [u8; 8],
 }
-impl ::device_driver::FieldSet for FooRwFieldSet {
-    const SIZE_BITS: u32 = 64;
+impl ::device_driver::Fieldset for FooRwFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }
@@ -395,8 +397,9 @@ pub struct FooRoFieldSet {
     /// The internal bits
     bits: [u8; 8],
 }
-impl ::device_driver::FieldSet for FooRoFieldSet {
-    const SIZE_BITS: u32 = 64;
+impl ::device_driver::Fieldset for FooRoFieldSet {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
     fn get_inner_buffer(&self) -> &[u8] {
         &self.bits
     }

--- a/tests/ui/cases/fieldset_access/input.ddsl
+++ b/tests/ui/cases/fieldset_access/input.ddsl
@@ -5,7 +5,7 @@ device Device {
         access: RO,
         address: 0,
         fields: fieldset foo_roFieldSet {
-            size-bits: 64,
+            size-bytes: 8,
 
             field value_ro RO 15:0 -> uint,
             field value_rw 31:16 -> int,
@@ -15,7 +15,7 @@ device Device {
     register foo_rw {
         address: 1,
         fields: fieldset foo_rwFieldSet {
-            size-bits: 64,
+            size-bytes: 8,
 
             field value_ro RO 15:0 -> uint,
             field value_rw 31:16 -> int,
@@ -26,7 +26,7 @@ device Device {
         access: WO,
         address: 2,
         fields: fieldset foo_woFieldSet {
-            size-bits: 64,
+            size-bytes: 8,
             field value_ro RO 15:0 -> uint,
             field value_rw 31:16 -> int,
             field value_wo WO 32 -> bool,


### PR DESCRIPTION
This means you can't specify arbitrary-width fieldsets anymore, but:
- There's some complexity to maintain it
- There's almost no device out there that actually requires it
- No driver written with the toolkit I can find uses the feature earnestly
- The semantics are not specified and in practice are unhelpful
- It's getting in the way of multi-register transactions

So I've decided it's got to go.
You now specify the amount of bytes.

In the future we can reimplement it if the feature is truly desired.