### PR TITLE
Fix integer reset value panic when >128 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- Fixed panic when using an integer reset value on a register larger than 128 bits.
+  Now you get an error telling you to specify the reset value as an array.
+
 ### 1.0.8 (06-03-25)
 
 - Removed KDL-gen since v2 isn't going to use KDL anymore

--- a/generation/src/mir/passes/reset_values_converted.rs
+++ b/generation/src/mir/passes/reset_values_converted.rs
@@ -127,6 +127,7 @@ fn convert_reset_value(
     let target_byte_size = size_bits.div_ceil(8) as usize;
 
     match reset_value {
+        ResetValue::Integer(0) => Ok(ResetValue::Array(vec![0; target_byte_size])),
         ResetValue::Integer(int) => {
             // Convert the integer to LE and LSB0
             let mut array = int.to_le_bytes();
@@ -135,6 +136,12 @@ fn convert_reset_value(
             }
 
             let array_view = array.view_bits_mut::<Lsb0>();
+
+            ensure!(
+                array_view.len() >= size_bits as usize,
+                "The reset value is specified as an integer. That integer is 128 bits, but the register is bigger with {size_bits} bits. \
+                The size of the reset value must match the register size, so please specify it in array form."
+            );
 
             // Check if the value is not too big
             ensure!(


### PR DESCRIPTION
This resulted in a panic:

```yaml
# manifest.yaml
config:
  register_address_type: u8
  default_byte_order: LE
  default_bit_order: LSB0

Reg:
  type: register
  address: 0x01
  access: RO
  size_bits: 264
  reset_value: 0x0
  fields:
    Head:
      base: uint
      start: 0
      end: 16
    Tail:
      base: uint
      start: 248
      end: 264
```

Now not anymore