### PR TITLE
Generate doc aliases

### DIFF
--- a/compiler/dd-codegen/src/rust.rs
+++ b/compiler/dd-codegen/src/rust.rs
@@ -101,3 +101,11 @@ fn get_address_mode_const_value(value: &Option<AddressMode>) -> &'static str {
         None => "()",
     }
 }
+
+fn maybe_doc_alias(identifier: &Identifier, case: Case) -> String {
+    if identifier.to_case(case) == identifier.original() {
+        return String::new();
+    }
+
+    format!("#[doc(alias = \"{}\")]", identifier.original())
+}

--- a/compiler/dd-codegen/templates/rust/block.rs.j2
+++ b/compiler/dd-codegen/templates/rust/block.rs.j2
@@ -6,6 +6,7 @@
 {% endif %}
 
 {{ self::description_to_docstring(block.description) }}
+{{ self::maybe_doc_alias(block.name, Case::Pascal) }}
 #[derive(Debug)]
 pub struct {{ block.name.to_case(Case::Pascal) }}{{block_generics}} {
     {% if block.root %}
@@ -45,6 +46,7 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
             {% when Repeat::Enum { .. } %}
             {% endwhen %}
         {% endmatch %}
+        {{ self::maybe_doc_alias(method.name, Case::Snake) }}
         pub fn {{ method.name.to_case(Case::Snake) }}(
             &mut self,
             {% if let BlockMethodType::Block { .. } = method.method_type %}

--- a/compiler/dd-codegen/templates/rust/enums.rs.j2
+++ b/compiler/dd-codegen/templates/rust/enums.rs.j2
@@ -1,4 +1,5 @@
 {{self::description_to_docstring(enum_value.description)}}
+{{ self::maybe_doc_alias(enum_value.name, Case::Pascal) }}
 #[repr({{enum_value.base_type}})]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 {% if let Some(defmt_feature) = defmt_feature() %}
@@ -6,7 +7,8 @@
 {% endif %}
 pub enum {{enum_value.name.to_case(Case::Pascal)}} {
     {% for variant in enum_value.variants %}
-        {{self::description_to_docstring(variant.description)}}
+        {{ self::description_to_docstring(variant.description) }}
+        {{ self::maybe_doc_alias(variant.name, Case::Pascal) }}
         {{variant.name.to_case(Case::Pascal)}} {% if variant.catch_all %} ({{enum_value.base_type}}) {% endif %} = {{variant.discriminant}},
     {% endfor %}
 }

--- a/compiler/dd-codegen/templates/rust/fieldset.rs.j2
+++ b/compiler/dd-codegen/templates/rust/fieldset.rs.j2
@@ -1,4 +1,5 @@
 {{self::description_to_docstring(field_set.description)}}
+{{ self::maybe_doc_alias(field_set.name, Case::Pascal) }}
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct {{field_set.name.to_case(Case::Pascal)}} {
@@ -18,7 +19,8 @@ impl {{field_set.name.to_case(Case::Pascal)}} {
         {% if matches!(field.access, Access::RW | Access::RO) %}
             /// `{{field.address_text()}}` - Read the `{{field.name.to_case(Case::Snake)}}` field.
             ///
-            {{self::description_to_docstring(field.description)}}
+            {{ self::description_to_docstring(field.description) }}
+            {{ self::maybe_doc_alias(field.name, Case::Snake) }}
             #[must_use]
             pub fn {{field.name.to_case(Case::Snake)}}(
                 &self,
@@ -70,7 +72,8 @@ impl {{field_set.name.to_case(Case::Pascal)}} {
         {% if matches!(field.access, Access::RW | Access::WO) %}
             /// `{{field.address_text()}}` - Set the `{{field.name.to_case(Case::Snake)}}` field.
             ///
-            {{self::description_to_docstring(field.description)}}
+            {{ self::description_to_docstring(field.description) }}
+            {{ self::maybe_doc_alias(field.name, Case::Snake) }}
             pub fn set_{{field.name.to_case(Case::Snake)}}(
                 &mut self,
                 {% match field.repeat %}

--- a/tests/ui/cases/address_types/address_types.rs
+++ b/tests/ui/cases/address_types/address_types.rs
@@ -21,6 +21,7 @@ impl<I> Device<I> {
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
+    #[doc(alias = "Foo")]
     pub fn foo(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -41,6 +42,7 @@ impl<I> Device<I> {
             FooFieldSet::default,
         )
     }
+    #[doc(alias = "Bar")]
     pub fn bar(&mut self) -> ::device_driver::CommandOperation<'_, Self, i32, (), ()>
     where
         I: ::device_driver::CommandInterfaceBase<AddressType = i32>,
@@ -48,6 +50,7 @@ impl<I> Device<I> {
         let address = self.base_address + 0;
         ::device_driver::CommandOperation::new(self, address as i32)
     }
+    #[doc(alias = "Quux")]
     pub fn quux(
         &mut self,
     ) -> ::device_driver::BufferOperation<'_, Self, i8, ::device_driver::RW>

--- a/tests/ui/cases/basic_command/basic_command.rs
+++ b/tests/ui/cases/basic_command/basic_command.rs
@@ -21,6 +21,7 @@ impl<I> Device<I> {
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
+    #[doc(alias = "Foo")]
     pub fn foo(
         &mut self,
     ) -> ::device_driver::CommandOperation<'_, Self, u8, FooFieldSetIn, ()>

--- a/tests/ui/cases/basic_register/basic_register.rs
+++ b/tests/ui/cases/basic_register/basic_register.rs
@@ -23,6 +23,7 @@ impl<I> Device<I> {
     pub const fn new(interface: I) -> Self {
         Self { interface, base_address: 0 }
     }
+    #[doc(alias = "Foo")]
     pub fn foo(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -48,6 +49,7 @@ impl<I> Device<I> {
     /// Reset value: `0x123456`
     ///
     /// Valid index range: `0..3`
+    #[doc(alias = "Bar")]
     pub fn bar(
         &mut self,
     ) -> ::device_driver::RegisterOperation<

--- a/tests/ui/cases/compile_time_explosion/compile_time_explosion.rs
+++ b/tests/ui/cases/compile_time_explosion/compile_time_explosion.rs
@@ -23,6 +23,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo0")]
     pub fn foo_0(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -41,6 +42,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo1")]
     pub fn foo_1(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -59,6 +61,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo2")]
     pub fn foo_2(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -77,6 +80,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo3")]
     pub fn foo_3(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -95,6 +99,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo4")]
     pub fn foo_4(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -113,6 +118,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo5")]
     pub fn foo_5(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -131,6 +137,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo6")]
     pub fn foo_6(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -149,6 +156,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo7")]
     pub fn foo_7(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -167,6 +175,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo8")]
     pub fn foo_8(
         &mut self,
     ) -> ::device_driver::RegisterOperation<
@@ -185,6 +194,7 @@ impl<I> Device<I> {
     }
     ///
     /// Valid index range: `0..100`
+    #[doc(alias = "Foo9")]
     pub fn foo_9(
         &mut self,
     ) -> ::device_driver::RegisterOperation<

--- a/tests/ui/cases/description_string_escapes/description_string_escapes.rs
+++ b/tests/ui/cases/description_string_escapes/description_string_escapes.rs
@@ -22,6 +22,7 @@ impl<I> Device<I> {
         Self { interface, base_address: 0 }
     }
     /// \\\\\\/\/\/\////\/\/;{}'"`'
+    #[doc(alias = "Foo")]
     pub fn foo(
         &mut self,
     ) -> ::device_driver::RegisterOperation<

--- a/tests/ui/cases/fieldset_access/fieldset_access.rs
+++ b/tests/ui/cases/fieldset_access/fieldset_access.rs
@@ -92,6 +92,7 @@ impl<I> ::device_driver::Block for Device<I> {
         &mut self.interface
     }
 }
+#[doc(alias = "foo_woFieldSet")]
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct FooWoFieldSet {
@@ -242,6 +243,7 @@ impl core::ops::Not for FooWoFieldSet {
         self
     }
 }
+#[doc(alias = "foo_rwFieldSet")]
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct FooRwFieldSet {
@@ -392,6 +394,7 @@ impl core::ops::Not for FooRwFieldSet {
         self
     }
 }
+#[doc(alias = "foo_roFieldSet")]
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct FooRoFieldSet {


### PR DESCRIPTION
Add doc aliases to generated code when the generated name is different from the original name.

This should make it easier to go between the DDSL source (and thus potentially the datasheet) and the generated code.