### PR TITLE
Add TI ADC Bus Expanders to the example list

### DIFF
--- a/book/src/preface.md
+++ b/book/src/preface.md
@@ -82,5 +82,6 @@ It's nice to have examples:
 - [ON Semiconductor CAT25040 4kbit SPI EEPROM](https://github.com/cesardtamayo/cat25040)
 - [TI BQ27441 Battery Fuel Gauge IC](https://github.com/leftger/bq27441)
 - [TI BQ25887 2-Cell Battery Charger IC](https://github.com/leftger/bq25887)
+- [TI ADC Bus Expanders](https://github.com/activexray/ti-adc-expander)
 
 Feel free to add to this list!


### PR DESCRIPTION
Hey there, thanks for the awesome crate!

 I've been using your library to simplify a driver for the family of TI ADC "bus expander" chips that worked out to be a perfect candidate. There was lots of overlapping features and chip variants for SPI/I2C, so this saved a ton of repeated code. I'm using this in production at work and would love to add to the list of examples. Thanks!