### PR TITLE
Make async RegisterOperation functions take self by value

### DIFF
--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -288,7 +288,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero`].
     #[track_caller]
     pub fn write_async(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
     where
@@ -313,7 +313,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero_at_async`].
     #[track_caller]
     pub fn write_at_async(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
@@ -341,7 +341,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_array_with_zero_at_async`].
     #[track_caller]
     pub fn write_array_at_async<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
@@ -449,7 +449,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_with_zero_async(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
     where
@@ -473,7 +473,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_with_zero_at_async(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
@@ -500,7 +500,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_array_with_zero_at_async<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
@@ -592,7 +592,7 @@ where
     /// Read the register from the device
     #[track_caller]
     pub fn read_async(
-        &mut self,
+        self,
     ) -> impl Future<Output = Result<RegisterFs, <B::Interface as RegisterInterfaceBase>::Error>>
     where
         Repeat: NotRepeating,
@@ -612,7 +612,7 @@ where
 
     /// Read the register from the device at a given index
     pub fn read_at_async(
-        &mut self,
+        self,
         index: Repeat::Index,
     ) -> impl Future<Output = Result<RegisterFs, <B::Interface as RegisterInterfaceBase>::Error>>
     where
@@ -635,7 +635,7 @@ where
 
     /// Read an array of registers from the device at a given index and length
     pub fn read_array_at_async<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
     ) -> impl Future<Output = Result<[RegisterFs; N], <B::Interface as RegisterInterfaceBase>::Error>>
     where
@@ -767,7 +767,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify_async(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
     where
@@ -798,7 +798,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify_at_async(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>
@@ -831,7 +831,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify_array_at_async<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> impl Future<Output = Result<(), <B::Interface as RegisterInterfaceBase>::Error>>

--- a/device-driver/src/register.rs
+++ b/device-driver/src/register.rs
@@ -208,7 +208,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero`].
     #[track_caller]
     pub fn write(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
     where
@@ -232,7 +232,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_with_zero_at`].
     #[track_caller]
     pub fn write_at(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
@@ -257,7 +257,7 @@ where
     /// If no reset value is specified for this register, this function is the same as [`Self::write_array_with_zero_at`].
     #[track_caller]
     pub fn write_array_at<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
@@ -372,7 +372,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_with_zero(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
     where
@@ -395,7 +395,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_with_zero_at(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
@@ -419,7 +419,7 @@ where
     /// The closure is given the write object initialized to all zero.
     #[track_caller]
     pub fn write_array_with_zero_at<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
@@ -528,7 +528,7 @@ where
 
     /// Read the register from the device
     #[track_caller]
-    pub fn read(&mut self) -> Result<RegisterFs, <B::Interface as RegisterInterfaceBase>::Error>
+    pub fn read(self) -> Result<RegisterFs, <B::Interface as RegisterInterfaceBase>::Error>
     where
         Repeat: NotRepeating,
         B::Interface: RegisterInterface,
@@ -545,7 +545,7 @@ where
     /// Read the register from the device at a given index
     #[track_caller]
     pub fn read_at(
-        &mut self,
+        self,
         index: Repeat::Index,
     ) -> Result<RegisterFs, <B::Interface as RegisterInterfaceBase>::Error>
     where
@@ -568,7 +568,7 @@ where
     /// Read an array of registers from the device at a given index and length
     #[track_caller]
     pub fn read_array_at<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
     ) -> Result<[RegisterFs; N], <B::Interface as RegisterInterfaceBase>::Error>
     where
@@ -665,7 +665,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify(
-        &mut self,
+        self,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
     where
@@ -696,7 +696,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify_at(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut RegisterFs),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>
@@ -729,7 +729,7 @@ where
     /// The result is then written back to the device.
     #[track_caller]
     pub fn modify_array_at<const N: usize>(
-        &mut self,
+        self,
         index: Repeat::Index,
         f: impl FnOnce(&mut [RegisterFs; N]),
     ) -> Result<(), <B::Interface as RegisterInterfaceBase>::Error>

--- a/device-driver/tests/basic-register-async.rs
+++ b/device-driver/tests/basic-register-async.rs
@@ -48,3 +48,16 @@ fn async_compiles() {
     let mut device = MyTestDevice::new(DeviceInterface);
     let _future = async { device.foo().read_async().await };
 }
+
+#[test]
+fn async_pass_through_compiles() {
+    // Compiles if we are able to construct pass-through futures
+    fn foo_read_async_pass_through(
+        device: &mut MyTestDevice<DeviceInterface>,
+    ) -> impl Future<Output = Result<FooFields, ()>> {
+        device.foo().read_async()
+    }
+
+    let mut device = MyTestDevice::new(DeviceInterface);
+    let _future = foo_read_async_pass_through(&mut device);
+}


### PR DESCRIPTION
Hey,

I have started playing around with this library, and inspired by your [blog post](https://tweedegolf.nl/en/blog/235/debloat-your-async-rust/) I wanted to make my own driver do most async operations using the pass-through pattern you suggest. However that is currently not easy to do with this library, since `RegisterOperation::{read, write, modify, etc..}_async` take `&mut self` rather than just `self`. So the returned future would borrow the `RegisterOperation` that is constructed locally in this function.

The result is that I am unable to do this:

```rust
pub fn read_acc_raw(&mut self) -> impl Future<Output = Result<[i16; 3], I::Error>> {
    self.inner
        .acc_data()
        .read_async()
        .map_ok(|data| [data.acc_x(), data.acc_y(), data.acc_z()])
}
```

but rather have to resort to async+awaiting:

```rust
pub fn read_acc_raw(&mut self) -> impl Future<Output = Result<[i16; 3], I::Error>> {
    async {
        self.inner
            .acc_data()
            .read_async()
            .map_ok(|data| [data.acc_x(), data.acc_y(), data.acc_z()])
            .await
    }
}

// Or just: pub async fn read_acc_raw(&mut self) -> Result<[i16; 3], I::Error>
```

This PR just change those `x_async` functions to take `self` rather than `&mut self` and all tests still seem to pass, and the first snippet above compiles. Of course this means one cannot construct a `RegisterOperation` once and re-use it multiple times, but I am also not sure if there is any benefit to that over just constructing it again. I have not touched the sync functions here, but perhaps they should also take `self` just for symmetry?