### PR TITLE
Make bulk ops use REAL tuples

### DIFF
--- a/device-driver/src/fieldset.rs
+++ b/device-driver/src/fieldset.rs
@@ -108,18 +108,18 @@ macro_rules! create_fsn {
         }
 
         impl<$($tname),*> ToTuple for $name<$($tname),*> {
-            type Tuple = ($($tname),*);
+            type Tuple = ($($tname),*,);
             fn to_tuple(self) -> Self::Tuple {
                 (
-                    $(self.$tnum),*
+                    $(self.$tnum),*,
                 )
             }
         }
         impl<'a, $($tname),*> ToTuple for &'a mut $name<$($tname),*> {
-            type Tuple = ($(&'a mut $tname),*);
+            type Tuple = ($(&'a mut $tname),*,);
             fn to_tuple(self) -> Self::Tuple {
                 (
-                    $(&mut self.$tnum),*
+                    $(&mut self.$tnum),*,
                 )
             }
         }

--- a/device-driver/tests/bulk-register.rs
+++ b/device-driver/tests/bulk-register.rs
@@ -237,3 +237,27 @@ fn plan_array_oob() {
         .bulk_read()
         .with(|d| d.foo_repeated().plan_array_at::<3>(2));
 }
+
+/// Show/test that bulk ops work with conditional compilation down to a single element too
+#[test]
+fn conditional() {
+    let mut device = MyTestDevice::new(DeviceInterface::new());
+
+    let bulk_write = device.bulk_write().with(|d| d.foo().plan());
+    #[cfg(false)]
+    let bulk_write = bulk_write.with(|d| d.bar().plan());
+    bulk_write
+        .execute(|vals| {
+            vals.0.set_value(42);
+            #[cfg(false)]
+            vals.1.set_value(42);
+        })
+        .unwrap();
+
+    let bulk_read = device.bulk_read().with(|d| d.foo().plan());
+    #[cfg(false)]
+    let bulk_read = bulk_read.with(|d| d.bar().plan());
+    let vals = bulk_read.execute().unwrap();
+
+    assert_eq!(vals.0.value(), 42)
+}


### PR DESCRIPTION
Single elements will now still remain tuples (with a single element).

Reasons:
- Consistency
- Enable conditional use of bulk
- Discourage bulk use for single items