### PR TITLE
Converter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy --features defmt -- -D warnings
+      - run: cargo clippy --features defmt,converter-dd-v1 -- -D warnings
 
   run-cli:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "rust-analyzer.linkedProjects": [
         "Cargo.toml",
     ],
-    "rust-analyzer.cargo.targetDir": true
+    "rust-analyzer.cargo.targetDir": true,
+    "rust-analyzer.cargo.features": ["gen-docs", "dd-v1", "converter-dd-v1"]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
     "compiler/dd-parser",
     "compiler/dd-wasm",
     "fuzz",
-    "tests/ui",
+    "tests/ui", "compiler/dd-converter",
 ]
 
 exclude = ["website"]
@@ -37,6 +37,7 @@ device-driver-lir = { path = "compiler/dd-lir", version = "=2.0.0-alpha.1" }
 device-driver-macros = { path = "compiler/dd-macros", version = "=2.0.0-alpha.1" }
 device-driver-mir = { path = "compiler/dd-mir", version = "=2.0.0-alpha.1" }
 device-driver-parser = { path = "compiler/dd-parser", version = "=2.0.0-alpha.1" }
+device-driver-converter = { path = "compiler/dd-converter", version = "=2.0.0-alpha.1" }
 
 itertools = "0.14.0"
 convert_case = "0.10.0"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -46,3 +46,4 @@
 # Addendum
 
 - [Memory](./memory.md)
+- [Migrating v1 to v2](./migration-v2.md)

--- a/book/src/gen-docs/README.md
+++ b/book/src/gen-docs/README.md
@@ -1,5 +1,5 @@
 Regenerate this folder by running this command from the root of repo:
 
 ```sh
-cargo +nightly run --features gen-docs -- gen-docs -o book/src/gen-docs
+cargo +nightly run --all-features -- gen-docs -o book/src/gen-docs
 ```

--- a/book/src/gen-docs/options/cli-converter-help.txt
+++ b/book/src/gen-docs/options/cli-converter-help.txt
@@ -1,0 +1,17 @@
+The format to convert into DDSL
+
+Usage: [OPTIONS] <COMMAND>
+
+Commands:
+  device-driver-v1  The v1 formats of device-driver (DSL, YAML, JSON & TOML)
+  help              Print this message or the help of the given subcommand(s)
+
+Options:
+  -s, --source <FILE>
+          Path to the input file
+
+  -o, --output <FILE>
+          Path to output location. Any existing file is overwritten. If not provided, the output is written to stdout
+
+  -h, --help
+          Print help

--- a/book/src/gen-docs/options/cli-help.txt
+++ b/book/src/gen-docs/options/cli-help.txt
@@ -5,6 +5,7 @@ Usage: ddc <COMMAND>
 Commands:
   build     Compile DDSL to the target output
   gen-docs  Generate docs about the compiler
+  convert   The format to convert into DDSL
   help      Print this message or the help of the given subcommand(s)
 
 Options:

--- a/book/src/migration-v2.md
+++ b/book/src/migration-v2.md
@@ -1,0 +1,85 @@
+# Migrating v1 to v2
+
+If you want to migrate an existing v1 driver to v2, you'll read some of the steps here and some of the issues you may encounter.
+
+## Convert
+
+The `ddc` cli can do a lot of the mechanical conversion for you.
+
+```sh
+ddc convert device-driver-v1 --sub-format yaml -s ./device.yaml -o ./device.ddsl
+```
+
+Change out the paths as you like and change the subformat to the format you've used. If you've been using the `create_device!` with the inline DSL, first copy the DSL to a file and feed that to the tool.
+
+If your install of `ddc` doesn't have the convert command, you need to reinstall it with the `--features converter-dd-v1` flag.
+
+The convert command converts the formats very straightforwardly and often doesn't do a perfect job, so some hand tuning is still required.
+
+### Cfg
+
+Cfg doesn't exist anymore and there's currently no replacement. If you really need this, you may need to keep your driver on v1. There are plans to build template support in the language: [issue](https://github.com/diondokter/device-driver/issues/58), so if you really need this and have ideas, please contribute there!
+
+The converter ignores cfg values.
+
+### Naming
+
+In v2, the names of objects is a little stricter. You may find that before you had a register, field and enum all with the same name. This would now clash since a register now has a named fieldset. Enums and fieldsets are types and they must not have the same name. See the section on [namespacing](./v2/language.md#namespacing).
+
+The converter copies the names as they were and does not fix them up. You'll have to figure out alternative names.
+
+### Ref objects
+
+Ref objects don't exist anymore. Ref registers and ref commands have good alternatives, though.
+
+Instead of having overrides, you simply copy the values as though it's a fully separate register or command. But then instead of defining a new fieldset, you can reuse a fieldset. The converter does this for you.
+
+For ref blocks you either have to do a bunch of copying manually, or use a (enum) repeat. The converter tool just copies everything (which will likely lead to name collisions you'll have to fix).
+
+### Extern types
+
+In v1 you could reference something that wasn't defined in the manifest. The generated code would then just use the name as is. This must now be done much more explicit as everything must be self-contained in the manifest.
+
+You must define an [extern](./v2/language-extern.md) object for every type reference that used to refer to a rust object. The converter does not do this for you as it can't know some of the metadata.
+
+### Formatting
+
+The converter doesn't know about number formatting and outputs everything in decimal.
+
+### Bit order
+
+Bit order doesn't exist anymore. It was a very hard feature to support for something that's barely ever used. Everything is now `lsb0`.
+
+If the converter finds something with `msb0`, it bails. Remove or change it in the v1 manifest and run the converter again.
+
+## Crate
+
+Now that we've converted the v1 yaml, json, toml or DSL to DDSL, we can focus on our Rust crate that requires some changes too.
+
+1. Update the device-driver dependency to 2.0.0 (or newer)
+   - If you're using the macro to compile the source, enable the `macros` feature on the crate
+2. If you're using macro to compile the source, update the macro:
+   ```rust
+    - device_driver::create_device!(
+    -     device_name: Device,
+    -     manifest: "device.yaml"
+    - );
+    + device_driver::compile!(
+    +     options: "--rust-defmt-feature=defmt",
+    +     manifest: "device.ddsl"
+    + );
+   ```
+   Note that the device name is now specified in the manifest and the defmt option at the compiler invocation.
+3. If you have a `build.rs`, check it and update any reference to the old manifest to the new file name.
+4. Update your interface types
+   - They now all have a base trait for the error and address types
+   - Size-bits is no longer given
+   - A metadata object is now given
+   - All buffers are now mutable for the case you need to do bit swaps
+5. Fieldsets are not generated into a module anymore. You may need to change some imports to remove the `field_sets` module from the path. The Rust compiler will tell you where this needs to happen.
+6. Fieldsets don't have a constructor anymore. If you've called the `new_zero()` on fieldsets before, you'll now need to use the `ZERO` associated const (for which you'll need to import the `Fieldset` trait from the device-driver crate).
+7. Repeat index parameter has moved. It used to be a parameter on the operation getter function. Now you specify it on the operation. For example:
+   ```rust
+   - device.foo(index).read()?;
+   + device.foo().read_at(index)?;
+   ```

--- a/book/src/v2/compilation.md
+++ b/book/src/v2/compilation.md
@@ -43,8 +43,10 @@ All Rust target specific features start with `--rust`.
 
 The cli can be installed using:
 ```sh
-cargo install device-driver-cli
+cargo install device-driver-cli --all-features
 ```
+
+It's possible to omit using `--all-features`, but you'll be missing some of the less important subcommands like `gen-docs` and `convert` (but it compiles faster).
 
 In the future more methods of distribution may become available. (If you have experience with this, help is very much wanted!)
 

--- a/book/src/v2/compilation.md
+++ b/book/src/v2/compilation.md
@@ -79,6 +79,15 @@ The output is unstable.
 {{#include ../gen-docs/options/cli-gen_docs-help.txt}}
 ```
 
+##### Converter
+
+Convert from one of the supported formats to DDSL.
+Don't rely on this in your main process since the output is unstable.
+
+```
+{{#include ../gen-docs/options/cli-converter-help.txt}}
+```
+
 ### Tool - Rust proc-macro
 
 To ease the compilation flow for Rust projects, a proc-macro is available.

--- a/compiler/dd-cli/Cargo.toml
+++ b/compiler/dd-cli/Cargo.toml
@@ -20,9 +20,16 @@ path = "src/main.rs"
 [dependencies]
 device-driver-core.workspace = true
 device-driver-diagnostics.workspace = true
+device-driver-converter = { workspace = true, optional = true }
 
 clap.workspace = true
 
 [features]
 # Enable the gen-docs command. Requires nightly to build
 gen-docs = ["device-driver-core/gen-docs"]
+
+# Enable converting device-driver v1 to DDSL
+converter-dd-v1 = ["_converter", "device-driver-converter/dd-v1"]
+
+# Private feature
+_converter = ["dep:device-driver-converter"]

--- a/compiler/dd-cli/src/main.rs
+++ b/compiler/dd-cli/src/main.rs
@@ -17,6 +17,8 @@ enum Command {
     /// Generate docs about the compiler
     #[cfg(feature = "gen-docs")]
     GenDocs(GenDocsArgs),
+    #[cfg(feature = "_converter")]
+    Convert(ConverterArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -40,6 +42,21 @@ struct GenDocsArgs {
     output_path: PathBuf,
 }
 
+#[cfg(feature = "_converter")]
+#[derive(Parser, Debug)]
+#[command(no_binary_name = true, bin_name = "")]
+struct ConverterArgs {
+    /// Path to the input file.
+    #[arg(short = 's', long = "source", value_name = "FILE", global = true)]
+    source_path: Option<PathBuf>,
+    /// Path to output location. Any existing file is overwritten. If not provided, the output is written to stdout.
+    #[arg(short = 'o', long = "output", value_name = "FILE", global = true)]
+    output_path: Option<PathBuf>,
+    /// The format to convert from
+    #[command(subcommand)]
+    source_format: device_driver_converter::SourceFormat,
+}
+
 fn main() -> ExitCode {
     match run() {
         Ok(exit) => exit,
@@ -57,6 +74,8 @@ fn run() -> Result<ExitCode, DynError> {
         Command::Build(args) => build(args),
         #[cfg(feature = "gen-docs")]
         Command::GenDocs(args) => gen_docs(args),
+        #[cfg(feature = "_converter")]
+        Command::Convert(args) => convert(args),
     }
 }
 
@@ -132,6 +151,11 @@ fn gen_docs(args: GenDocsArgs) -> Result<ExitCode, DynError> {
     )
     .with_message(|| "writing cli-gen_docs-help")?;
     std::fs::write(
+        cli_folder.join("cli-converter-help.txt"),
+        ConverterArgs::command().render_long_help().to_string(),
+    )
+    .with_message(|| "writing cli-gen_docs-help")?;
+    std::fs::write(
         cli_folder.join("cli-gen_docs-help.txt"),
         GenDocsArgs::command().render_long_help().to_string(),
     )
@@ -152,6 +176,40 @@ fn gen_docs(args: GenDocsArgs) -> Result<ExitCode, DynError> {
     .with_message(|| "writing rust-help")?;
 
     device_driver_core::gen_docs(&args.output_path).map(|()| ExitCode::SUCCESS)
+}
+
+#[cfg(feature = "_converter")]
+fn convert(args: ConverterArgs) -> Result<ExitCode, DynError> {
+    let Some(source_path) = args.source_path else {
+        return Err(DynError::new("no source path provided"));
+    };
+
+    let source = std::fs::read_to_string(&source_path)
+        .with_message(|| format!("Failed to open input file at: {:?}", source_path.display()))?;
+
+    let ddsl = device_driver_converter::convert(&source, args.source_format)
+        .with_message(|| "converting source")?;
+
+    let output_writer: &mut dyn Write = match &args.output_path {
+        Some(path) => &mut std::fs::File::create(path).with_message(|| {
+            format!(
+                "could not create the output file at: {:?}. Does its directory exist?",
+                path.display()
+            )
+        })?,
+        None => &mut std::io::stdout().lock(),
+    };
+
+    let mut output_writer = std::io::BufWriter::new(output_writer);
+    output_writer.write_all(ddsl.as_bytes()).with_message(|| {
+        format!(
+            "could not write output to {}",
+            args.output_path
+                .map_or_else(|| "stdout".into(), |path| format!("{:?}", path.display()))
+        )
+    })?;
+
+    Ok(ExitCode::SUCCESS)
 }
 
 #[derive(clap::ValueEnum, Debug, Clone)]

--- a/compiler/dd-common/src/specifiers.rs
+++ b/compiler/dd-common/src/specifiers.rs
@@ -282,7 +282,7 @@ impl BaseType {
 impl Display for BaseType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BaseType::Unspecified => write!(f, "unspecified"),
+            BaseType::Unspecified => write!(f, "_"),
             BaseType::Bool => write!(f, "bool"),
             BaseType::Uint => write!(f, "uint"),
             BaseType::Int => write!(f, "int"),

--- a/compiler/dd-converter/Cargo.toml
+++ b/compiler/dd-converter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "device-driver-converter"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+device-driver-diagnostics.workspace = true
+device-driver-parser.workspace = true
+device-driver-common.workspace = true
+itertools.workspace = true
+clap.workspace = true
+
+device-driver-generation = { version = "=1.0.9", optional = true }
+dd-v1-convert_case = { package = "convert_case", version = "0.6.0", optional = true }
+
+[features]
+dd-v1 = ["dep:device-driver-generation", "dep:dd-v1-convert_case"]

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -9,8 +9,8 @@ use device_driver_common::{
 use device_driver_diagnostics::{DynError, ResultExt};
 use device_driver_generation::mir::{
     Access as V1Access, BaseType as V1BaseType, BitOrder, Block, Buffer, ByteOrder as V1ByteOrder,
-    Command, Enum, Field, FieldConversion, Integer as V1Integer, Object, Register,
-    Repeat as V1Repeat,
+    Command, Enum, Field, FieldConversion, Integer as V1Integer, Object, ObjectOverride, RefObject,
+    Register, Repeat as V1Repeat,
 };
 use device_driver_parser::{
     Expression, Ident, Node, Property, Repeat, RepeatSource, TypeConversion, TypeSpecifier,
@@ -101,7 +101,8 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
             .objects
             .iter()
             .map(|o| {
-                convert_object(o).with_message(|| format!("converting object `{}`", object_name(o)))
+                convert_object(o, &device_mir.objects)
+                    .with_message(|| format!("converting object `{}`", object_name(o)))
             })
             .collect::<Result<Vec<_>, _>>()?,
         span: Span::empty(),
@@ -152,29 +153,114 @@ fn convert_boundary(value: &Boundary) -> &'static str {
     }
 }
 
-fn convert_object(object: &Object) -> Result<Node<'static>, DynError> {
+fn convert_object(object: &Object, all_objects: &[Object]) -> Result<Node<'static>, DynError> {
     let node = match object {
-        Object::Block(block) => convert_block(block)?,
-        Object::Register(register) => convert_register(register)?,
-        Object::Command(command) => convert_command(command)?,
+        Object::Block(block) => convert_block(block, all_objects)?,
+        Object::Register(register) => convert_register(register, None)?,
+        Object::Command(command) => convert_command(command, None, None)?,
         Object::Buffer(buffer) => convert_buffer(buffer)?,
-        Object::Ref(ref_object) => Node {
-            doc_comments: Vec::new(),
-            node_type: Ident::new_no_span("todo-ref"),
-            name: Ident::new_no_span(ref_object.name.clone().leak()),
-            repeat: None,
-            type_specifier: None,
-            short_properties: Vec::new(),
-            properties: Vec::new(),
-            sub_nodes: Vec::new(),
-            span: Span::empty(),
-        },
+        Object::Ref(ref_object) => convert_ref_object(ref_object, all_objects)?,
     };
 
     Ok(node)
 }
 
-fn convert_register(register: &Register) -> Result<Node<'static>, DynError> {
+fn convert_ref_object(
+    ref_object: &RefObject,
+    all_objects: &[Object],
+) -> Result<Node<'static>, DynError> {
+    match &ref_object.object_override {
+        ObjectOverride::Block(block_override) => {
+            let Some(Object::Block(original_block)) = all_objects
+                .iter()
+                .find(|o| object_name(o) == block_override.name)
+            else {
+                return Err(DynError::new("could not find the original block"));
+            };
+
+            let overridden_block = Block {
+                cfg_attr: original_block.cfg_attr.clone(),
+                description: ref_object.description.clone(),
+                name: ref_object.name.clone(),
+                address_offset: block_override
+                    .address_offset
+                    .unwrap_or(original_block.address_offset),
+                repeat: block_override.repeat.or(original_block.repeat),
+                objects: original_block.objects.clone(),
+            };
+
+            convert_block(&overridden_block, all_objects)
+        }
+        ObjectOverride::Register(register_override) => {
+            let Some(Object::Register(original_register)) = all_objects
+                .iter()
+                .find(|o| object_name(o) == register_override.name)
+            else {
+                return Err(DynError::new("could not find the original register"));
+            };
+
+            let overridden_register = Register {
+                cfg_attr: original_register.cfg_attr.clone(),
+                description: ref_object.description.clone(),
+                name: ref_object.name.clone(),
+                access: register_override.access.unwrap_or(original_register.access),
+                byte_order: Default::default(),
+                bit_order: Default::default(),
+                allow_bit_overlap: Default::default(),
+                allow_address_overlap: register_override.allow_address_overlap,
+                address: register_override
+                    .address
+                    .unwrap_or(original_register.address),
+                size_bits: Default::default(),
+                reset_value: register_override
+                    .reset_value
+                    .clone()
+                    .or(original_register.reset_value.clone()),
+                repeat: register_override.repeat.or(original_register.repeat),
+                fields: Default::default(),
+            };
+
+            convert_register(&overridden_register, Some(register_override.name.clone()))
+        }
+        ObjectOverride::Command(command_override) => {
+            let Some(Object::Command(original_command)) = all_objects
+                .iter()
+                .find(|o| object_name(o) == command_override.name)
+            else {
+                return Err(DynError::new("could not find the original command"));
+            };
+
+            let overridden_command = Command {
+                cfg_attr: original_command.cfg_attr.clone(),
+                description: ref_object.description.clone(),
+                name: ref_object.name.clone(),
+                byte_order: Default::default(),
+                bit_order: Default::default(),
+                allow_bit_overlap: Default::default(),
+                allow_address_overlap: command_override.allow_address_overlap,
+                address: command_override.address.unwrap_or(original_command.address),
+                size_bits_in: Default::default(),
+                size_bits_out: Default::default(),
+                repeat: command_override.repeat.or(original_command.repeat),
+                in_fields: Default::default(),
+                out_fields: Default::default(),
+            };
+
+            convert_command(
+                &overridden_command,
+                (!original_command.in_fields.is_empty())
+                    .then(|| format!("{}FieldsIn", original_command.name)),
+                (!original_command.out_fields.is_empty())
+                    .then(|| format!("{}FieldsOut", original_command.name)),
+            )
+        }
+    }
+}
+
+fn convert_register(
+    register: &Register,
+    fieldset_override: Option<String>,
+) -> Result<Node<'static>, DynError> {
     Ok(Node {
         doc_comments: register
             .description
@@ -227,17 +313,21 @@ fn convert_register(register: &Register) -> Result<Node<'static>, DynError> {
                 Property {
                     doc_comments: Vec::new(),
                     name: Ident::new_no_span("fields"),
-                    expression: Expression::SubNode(Box::new(
-                        convert_fieldset(
-                            None,
-                            register.byte_order,
-                            register.bit_order,
-                            register.allow_bit_overlap,
-                            register.size_bits,
-                            &register.fields,
-                        )
-                        .with_message(|| "converting fieldset")?,
-                    ))
+                    expression: if let Some(fieldset_override) = fieldset_override {
+                        Expression::TypeReference(Ident::new_no_span(fieldset_override.leak()))
+                    } else {
+                        Expression::SubNode(Box::new(
+                            convert_fieldset(
+                                None,
+                                register.byte_order,
+                                register.bit_order,
+                                register.allow_bit_overlap,
+                                register.size_bits,
+                                &register.fields,
+                            )
+                            .with_message(|| "converting fieldset")?,
+                        ))
+                    }
                     .with_dummy_span(),
                 }
                 .with_dummy_span(),
@@ -251,7 +341,11 @@ fn convert_register(register: &Register) -> Result<Node<'static>, DynError> {
     })
 }
 
-fn convert_command(command: &Command) -> Result<Node<'static>, DynError> {
+fn convert_command(
+    command: &Command,
+    fieldset_in_override: Option<String>,
+    fieldset_out_override: Option<String>,
+) -> Result<Node<'static>, DynError> {
     Ok(Node {
         doc_comments: command
             .description
@@ -284,43 +378,55 @@ fn convert_command(command: &Command) -> Result<Node<'static>, DynError> {
                 }
                 .with_dummy_span()
             }),
-            (!command.in_fields.is_empty())
+            (!command.in_fields.is_empty() || fieldset_in_override.is_some())
                 .then(|| {
                     Ok(Property {
                         doc_comments: Vec::new(),
                         name: Ident::new_no_span("fields-in"),
-                        expression: Expression::SubNode(Box::new(
-                            convert_fieldset(
-                                Some(format!("{}FieldsIn", command.name)),
-                                command.byte_order,
-                                command.bit_order,
-                                command.allow_bit_overlap,
-                                command.size_bits_in,
-                                &command.in_fields,
-                            )
-                            .with_message(|| "converting in fieldset")?,
-                        ))
+                        expression: if let Some(fieldset_in_override) = fieldset_in_override {
+                            Expression::TypeReference(Ident::new_no_span(
+                                fieldset_in_override.leak(),
+                            ))
+                        } else {
+                            Expression::SubNode(Box::new(
+                                convert_fieldset(
+                                    Some(format!("{}FieldsIn", command.name)),
+                                    command.byte_order,
+                                    command.bit_order,
+                                    command.allow_bit_overlap,
+                                    command.size_bits_in,
+                                    &command.in_fields,
+                                )
+                                .with_message(|| "converting in fieldset")?,
+                            ))
+                        }
                         .with_dummy_span(),
                     }
                     .with_dummy_span())
                 })
                 .transpose()?,
-            (!command.out_fields.is_empty())
+            (!command.out_fields.is_empty() || fieldset_out_override.is_some())
                 .then(|| {
                     Ok(Property {
                         doc_comments: Vec::new(),
                         name: Ident::new_no_span("fields-out"),
-                        expression: Expression::SubNode(Box::new(
-                            convert_fieldset(
-                                Some(format!("{}FieldsOut", command.name)),
-                                command.byte_order,
-                                command.bit_order,
-                                command.allow_bit_overlap,
-                                command.size_bits_out,
-                                &command.out_fields,
-                            )
-                            .with_message(|| "converting out fieldset")?,
-                        ))
+                        expression: if let Some(fieldset_out_override) = fieldset_out_override {
+                            Expression::TypeReference(Ident::new_no_span(
+                                fieldset_out_override.leak(),
+                            ))
+                        } else {
+                            Expression::SubNode(Box::new(
+                                convert_fieldset(
+                                    Some(format!("{}FieldsOut", command.name)),
+                                    command.byte_order,
+                                    command.bit_order,
+                                    command.allow_bit_overlap,
+                                    command.size_bits_out,
+                                    &command.out_fields,
+                                )
+                                .with_message(|| "converting out fieldset")?,
+                            ))
+                        }
                         .with_dummy_span(),
                     }
                     .with_dummy_span())
@@ -474,7 +580,7 @@ fn convert_buffer(buffer: &Buffer) -> Result<Node<'static>, DynError> {
     })
 }
 
-fn convert_block(block: &Block) -> Result<Node<'static>, DynError> {
+fn convert_block(block: &Block, all_objects: &[Object]) -> Result<Node<'static>, DynError> {
     Ok(Node {
         doc_comments: block
             .description
@@ -502,7 +608,8 @@ fn convert_block(block: &Block) -> Result<Node<'static>, DynError> {
             .objects
             .iter()
             .map(|o| {
-                convert_object(o).with_message(|| format!("converting object {}", object_name(o)))
+                convert_object(o, all_objects)
+                    .with_message(|| format!("converting object {}", object_name(o)))
             })
             .collect::<Result<Vec<_>, _>>()?,
         span: Span::empty(),

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -4,14 +4,17 @@ use crate::DeviceDriverV1Format;
 use dd_v1_convert_case::Boundary;
 use device_driver_common::{
     span::{Span, SpanExt},
-    specifiers::{Access, ByteOrder, Integer},
+    specifiers::{Access, BaseType, ByteOrder, Integer},
 };
 use device_driver_diagnostics::{DynError, ResultExt};
 use device_driver_generation::mir::{
-    Access as V1Access, BitOrder, Block, Buffer, ByteOrder as V1ByteOrder, Command, Field,
-    Integer as V1Integer, Object, Register, Repeat as V1Repeat,
+    Access as V1Access, BaseType as V1BaseType, BitOrder, Block, Buffer, ByteOrder as V1ByteOrder,
+    Command, Enum, Field, FieldConversion, Integer as V1Integer, Object, Register,
+    Repeat as V1Repeat,
 };
-use device_driver_parser::{Expression, Ident, Node, Property, Repeat, RepeatSource};
+use device_driver_parser::{
+    Expression, Ident, Node, Property, Repeat, RepeatSource, TypeConversion, TypeSpecifier,
+};
 use itertools::Itertools;
 
 pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String, DynError> {
@@ -398,12 +401,42 @@ fn convert_fieldset(
 
 fn convert_field(field: &Field) -> Result<Node<'static>, DynError> {
     Ok(Node {
-        doc_comments: Vec::new(),
-        node_type: Ident::new_no_span("todo-field"),
+        doc_comments: field
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("field"),
         name: Ident::new_no_span(field.name.clone().leak()),
         repeat: None,
-        type_specifier: None,
-        short_properties: Vec::new(),
+        type_specifier: Some(
+            TypeSpecifier {
+                base_type: convert_base_type(field.base_type).with_dummy_span(),
+                use_try: field
+                    .field_conversion
+                    .as_ref()
+                    .is_some_and(|fc| fc.use_try()),
+                conversion: field
+                    .field_conversion
+                    .as_ref()
+                    .map(convert_field_conversion),
+            }
+            .with_dummy_span(),
+        ),
+        short_properties: [
+            if field.field_address.len() == 1 {
+                Expression::Number(field.field_address.start.into())
+            } else {
+                Expression::AddressRange {
+                    end: (field.field_address.end - 1).into(),
+                    start: field.field_address.start.into(),
+                }
+            }
+            .with_dummy_span(),
+            Expression::Access(convert_access(field.access)).with_dummy_span(),
+        ]
+        .into_iter()
+        .collect(),
         properties: Vec::new(),
         sub_nodes: Vec::new(),
         span: Span::empty(),
@@ -498,5 +531,71 @@ fn object_name(object: &Object) -> &str {
         Object::Command(command) => &command.name,
         Object::Buffer(buffer) => &buffer.name,
         Object::Ref(ref_object) => &ref_object.name,
+    }
+}
+
+fn convert_base_type(value: V1BaseType) -> BaseType {
+    match value {
+        V1BaseType::Unspecified => BaseType::Unspecified,
+        V1BaseType::Bool => BaseType::Bool,
+        V1BaseType::Uint => BaseType::Uint,
+        V1BaseType::Int => BaseType::Int,
+        V1BaseType::FixedSize(integer) => BaseType::FixedSize(convert_integer(integer)),
+    }
+}
+
+fn convert_field_conversion(fs: &FieldConversion) -> TypeConversion<'static> {
+    match fs {
+        FieldConversion::Direct { type_name, .. } => {
+            TypeConversion::Reference(Ident::new_no_span(type_name.clone().leak()))
+        }
+        FieldConversion::Enum { enum_value, .. } => {
+            TypeConversion::Subnode(Box::new(convert_enum(enum_value)))
+        }
+    }
+}
+
+fn convert_enum(enum_value: &Enum) -> Node<'static> {
+    Node {
+        doc_comments: enum_value
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("enum"),
+        name: Ident::new_no_span(enum_value.name.clone().leak()),
+        repeat: None,
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: enum_value
+            .variants
+            .iter()
+            .map(|variant| {
+                Property {
+                    doc_comments: variant
+                        .description
+                        .lines()
+                        .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+                        .collect(),
+                    name: Ident::new_no_span(variant.name.clone().leak()),
+                    expression: match variant.value {
+                        device_driver_generation::mir::EnumValue::Unspecified => Expression::Auto,
+                        device_driver_generation::mir::EnumValue::Specified(num) => {
+                            Expression::Number(num)
+                        }
+                        device_driver_generation::mir::EnumValue::Default => {
+                            Expression::DefaultNumber(None)
+                        }
+                        device_driver_generation::mir::EnumValue::CatchAll => {
+                            Expression::CatchAllNumber(None)
+                        }
+                    }
+                    .with_dummy_span(),
+                }
+                .with_dummy_span()
+            })
+            .collect(),
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
     }
 }

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -41,7 +41,7 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
     let ddsl_root = Node {
         doc_comments: Vec::new(),
         node_type: Ident::new_no_span("device"),
-        name: Ident::new_no_span(device_mir.name.as_deref().unwrap_or("ConvertedDevice")),
+        name: Ident::new_no_span(device_mir.name.as_deref().unwrap_or("Device")),
         repeat: None,
         type_specifier: None,
         short_properties: Vec::new(),

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -309,6 +309,15 @@ fn convert_register(
                 }
                 .with_dummy_span()
             }),
+            (!matches!(register.access, V1Access::RW)).then(|| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("access"),
+                    expression: Expression::Access(convert_access(register.access))
+                        .with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
             Some(
                 Property {
                     doc_comments: Vec::new(),
@@ -506,6 +515,11 @@ fn convert_fieldset(
 }
 
 fn convert_field(field: &Field) -> Result<Node<'static>, DynError> {
+    let field_len = field.field_address.len();
+    let use_auto_base_type = (field.base_type == V1BaseType::Bool && field_len == 1)
+        || (field.base_type == V1BaseType::Uint && field_len >= 1);
+    let use_type_specifier = !use_auto_base_type || field.field_conversion.is_some();
+
     Ok(Node {
         doc_comments: field
             .description
@@ -515,9 +529,14 @@ fn convert_field(field: &Field) -> Result<Node<'static>, DynError> {
         node_type: Ident::new_no_span("field"),
         name: Ident::new_no_span(field.name.clone().leak()),
         repeat: None,
-        type_specifier: Some(
+        type_specifier: use_type_specifier.then(|| {
             TypeSpecifier {
-                base_type: convert_base_type(field.base_type).with_dummy_span(),
+                base_type: if use_auto_base_type {
+                    BaseType::Unspecified
+                } else {
+                    convert_base_type(field.base_type)
+                }
+                .with_dummy_span(),
                 use_try: field
                     .field_conversion
                     .as_ref()
@@ -527,21 +546,25 @@ fn convert_field(field: &Field) -> Result<Node<'static>, DynError> {
                     .as_ref()
                     .map(convert_field_conversion),
             }
-            .with_dummy_span(),
-        ),
+            .with_dummy_span()
+        }),
         short_properties: [
-            if field.field_address.len() == 1 {
-                Expression::Number(field.field_address.start.into())
-            } else {
-                Expression::AddressRange {
-                    end: (field.field_address.end - 1).into(),
-                    start: field.field_address.start.into(),
+            Some(
+                if field_len == 1 {
+                    Expression::Number(field.field_address.start.into())
+                } else {
+                    Expression::AddressRange {
+                        end: (field.field_address.end - 1).into(),
+                        start: field.field_address.start.into(),
+                    }
                 }
-            }
-            .with_dummy_span(),
-            Expression::Access(convert_access(field.access)).with_dummy_span(),
+                .with_dummy_span(),
+            ),
+            (!matches!(field.access, V1Access::RW))
+                .then(|| Expression::Access(convert_access(field.access)).with_dummy_span()),
         ]
         .into_iter()
+        .flatten()
         .collect(),
         properties: Vec::new(),
         sub_nodes: Vec::new(),
@@ -561,20 +584,27 @@ fn convert_buffer(buffer: &Buffer) -> Result<Node<'static>, DynError> {
         repeat: None,
         type_specifier: None,
         short_properties: Vec::new(),
-        properties: vec![
-            Property {
-                doc_comments: Vec::new(),
-                name: Ident::new_no_span("access"),
-                expression: Expression::Access(convert_access(buffer.access)).with_dummy_span(),
-            }
-            .with_dummy_span(),
-            Property {
-                doc_comments: Vec::new(),
-                name: Ident::new_no_span("address"),
-                expression: Expression::Number(buffer.address.into()).with_dummy_span(),
-            }
-            .with_dummy_span(),
-        ],
+        properties: [
+            (!matches!(buffer.access, V1Access::RW)).then(|| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("access"),
+                    expression: Expression::Access(convert_access(buffer.access)).with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+            Some(
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("address"),
+                    expression: Expression::Number(buffer.address.into()).with_dummy_span(),
+                }
+                .with_dummy_span(),
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
         sub_nodes: Vec::new(),
         span: Span::empty(),
     })

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -1,0 +1,133 @@
+use crate::DeviceDriverV1Format;
+use dd_v1_convert_case::Boundary;
+use device_driver_common::{
+    span::{Span, SpanExt},
+    specifiers::{ByteOrder, Integer},
+};
+use device_driver_diagnostics::{DynError, ResultExt};
+use device_driver_generation::mir::{ByteOrder as V1ByteOrder, Integer as V1Integer};
+use device_driver_parser::{Expression, Ident, Node, Property};
+use itertools::Itertools;
+
+pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String, DynError> {
+    let device_mir = match sub_format {
+        DeviceDriverV1Format::DSL => device_driver_generation::_private_transform_dsl_mir(
+            source
+                .parse()
+                .map_err(|e| DynError::new(e))
+                .with_message(|| "parsing source into tokenstream")?,
+        )
+        .into_dyn_result(),
+        DeviceDriverV1Format::YAML => device_driver_generation::_private_transform_yaml_mir(source)
+            .map_err(|e| DynError::new(e)),
+        DeviceDriverV1Format::JSON => device_driver_generation::_private_transform_json_mir(source)
+            .map_err(|e| DynError::new(e)),
+        DeviceDriverV1Format::TOML => device_driver_generation::_private_transform_toml_mir(source)
+            .map_err(|e| DynError::new(e)),
+    }
+    .with_message(|| "transforming source into v1 mir")?;
+
+    let ddsl_root = Node {
+        doc_comments: Vec::new(),
+        node_type: Ident::new_no_span("device"),
+        name: Ident::new_no_span(device_mir.name.as_deref().unwrap_or("ConvertedDevice")),
+        repeat: None,
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: [
+            device_mir
+                .global_config
+                .default_byte_order
+                .map(|val| Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("byte-order"),
+                    expression: Expression::ByteOrder(convert_byte_order(val)).with_dummy_span(),
+                }),
+            device_mir
+                .global_config
+                .register_address_type
+                .map(|val| Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("register-address-type"),
+                    expression: Expression::Integer(convert_integer(val)).with_dummy_span(),
+                }),
+            device_mir
+                .global_config
+                .command_address_type
+                .map(|val| Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("command-address-type"),
+                    expression: Expression::Integer(convert_integer(val)).with_dummy_span(),
+                }),
+            device_mir
+                .global_config
+                .buffer_address_type
+                .map(|val| Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("buffer-address-type"),
+                    expression: Expression::Integer(convert_integer(val)).with_dummy_span(),
+                }),
+            Some(Property {
+                doc_comments: Vec::new(),
+                name: Ident::new_no_span("word-boundaries"),
+                expression: Expression::String(
+                    device_mir
+                        .global_config
+                        .name_word_boundaries
+                        .iter()
+                        .map(convert_boundary)
+                        .join(":")
+                        .leak(),
+                )
+                .with_dummy_span(),
+            }),
+        ]
+        .into_iter()
+        .flatten()
+        .map(SpanExt::with_dummy_span)
+        .collect(),
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
+    };
+
+    Ok(ddsl_root.to_string())
+}
+
+fn convert_integer(value: V1Integer) -> Integer {
+    match value {
+        V1Integer::U8 => Integer::U8,
+        V1Integer::U16 => Integer::U16,
+        V1Integer::U32 => Integer::U32,
+        V1Integer::I8 => Integer::I8,
+        V1Integer::I16 => Integer::I16,
+        V1Integer::I32 => Integer::I32,
+        V1Integer::I64 => Integer::I64,
+    }
+}
+
+fn convert_byte_order(value: V1ByteOrder) -> ByteOrder {
+    match value {
+        V1ByteOrder::LE => ByteOrder::LE,
+        V1ByteOrder::BE => ByteOrder::BE,
+    }
+}
+
+fn convert_boundary(value: &Boundary) -> &'static str {
+    match value {
+        dd_v1_convert_case::Boundary::Hyphen => "-",
+        dd_v1_convert_case::Boundary::Underscore => "_",
+        dd_v1_convert_case::Boundary::Space => " ",
+        dd_v1_convert_case::Boundary::UpperLower => "Aa",
+        dd_v1_convert_case::Boundary::LowerUpper => "bB",
+        dd_v1_convert_case::Boundary::DigitUpper => "1A",
+        dd_v1_convert_case::Boundary::UpperDigit => "A1",
+        dd_v1_convert_case::Boundary::DigitLower => "1a",
+        dd_v1_convert_case::Boundary::LowerDigit => "a1",
+        dd_v1_convert_case::Boundary::Acronym => "AAa",
+    }
+}
+
+fn convert_object() {
+    // Remember to take the default accesses into account! Doesn't exist in DDSL
+    todo!()
+}

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -1,12 +1,17 @@
+use std::num::NonZeroU32;
+
 use crate::DeviceDriverV1Format;
 use dd_v1_convert_case::Boundary;
 use device_driver_common::{
     span::{Span, SpanExt},
-    specifiers::{ByteOrder, Integer},
+    specifiers::{Access, ByteOrder, Integer},
 };
 use device_driver_diagnostics::{DynError, ResultExt};
-use device_driver_generation::mir::{ByteOrder as V1ByteOrder, Integer as V1Integer};
-use device_driver_parser::{Expression, Ident, Node, Property};
+use device_driver_generation::mir::{
+    Access as V1Access, BitOrder, Block, Buffer, ByteOrder as V1ByteOrder, Command, Field,
+    Integer as V1Integer, Object, Register, Repeat as V1Repeat,
+};
+use device_driver_parser::{Expression, Ident, Node, Property, Repeat, RepeatSource};
 use itertools::Itertools;
 
 pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String, DynError> {
@@ -14,16 +19,19 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
         DeviceDriverV1Format::DSL => device_driver_generation::_private_transform_dsl_mir(
             source
                 .parse()
-                .map_err(|e| DynError::new(e))
+                .map_err(DynError::new)
                 .with_message(|| "parsing source into tokenstream")?,
         )
         .into_dyn_result(),
-        DeviceDriverV1Format::YAML => device_driver_generation::_private_transform_yaml_mir(source)
-            .map_err(|e| DynError::new(e)),
-        DeviceDriverV1Format::JSON => device_driver_generation::_private_transform_json_mir(source)
-            .map_err(|e| DynError::new(e)),
-        DeviceDriverV1Format::TOML => device_driver_generation::_private_transform_toml_mir(source)
-            .map_err(|e| DynError::new(e)),
+        DeviceDriverV1Format::YAML => {
+            device_driver_generation::_private_transform_yaml_mir(source).map_err(DynError::new)
+        }
+        DeviceDriverV1Format::JSON => {
+            device_driver_generation::_private_transform_json_mir(source).map_err(DynError::new)
+        }
+        DeviceDriverV1Format::TOML => {
+            device_driver_generation::_private_transform_toml_mir(source).map_err(DynError::new)
+        }
     }
     .with_message(|| "transforming source into v1 mir")?;
 
@@ -86,7 +94,13 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
         .flatten()
         .map(SpanExt::with_dummy_span)
         .collect(),
-        sub_nodes: Vec::new(),
+        sub_nodes: device_mir
+            .objects
+            .iter()
+            .map(|o| {
+                convert_object(o).with_message(|| format!("converting object `{}`", object_name(o)))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
         span: Span::empty(),
     };
 
@@ -112,6 +126,14 @@ fn convert_byte_order(value: V1ByteOrder) -> ByteOrder {
     }
 }
 
+fn convert_access(value: V1Access) -> Access {
+    match value {
+        V1Access::RW => Access::RW,
+        V1Access::RO => Access::RO,
+        V1Access::WO => Access::WO,
+    }
+}
+
 fn convert_boundary(value: &Boundary) -> &'static str {
     match value {
         dd_v1_convert_case::Boundary::Hyphen => "-",
@@ -127,7 +149,354 @@ fn convert_boundary(value: &Boundary) -> &'static str {
     }
 }
 
-fn convert_object() {
-    // Remember to take the default accesses into account! Doesn't exist in DDSL
-    todo!()
+fn convert_object(object: &Object) -> Result<Node<'static>, DynError> {
+    let node = match object {
+        Object::Block(block) => convert_block(block)?,
+        Object::Register(register) => convert_register(register)?,
+        Object::Command(command) => convert_command(command)?,
+        Object::Buffer(buffer) => convert_buffer(buffer)?,
+        Object::Ref(ref_object) => Node {
+            doc_comments: Vec::new(),
+            node_type: Ident::new_no_span("todo-ref"),
+            name: Ident::new_no_span(ref_object.name.clone().leak()),
+            repeat: None,
+            type_specifier: None,
+            short_properties: Vec::new(),
+            properties: Vec::new(),
+            sub_nodes: Vec::new(),
+            span: Span::empty(),
+        },
+    };
+
+    Ok(node)
+}
+
+fn convert_register(register: &Register) -> Result<Node<'static>, DynError> {
+    Ok(Node {
+        doc_comments: register
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("register"),
+        name: Ident::new_no_span(register.name.clone().leak()),
+        repeat: register
+            .repeat
+            .map(convert_repeat)
+            .transpose()?
+            .map(SpanExt::with_dummy_span),
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: [
+            Some(
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("address"),
+                    expression: Expression::Number(register.address.into()).with_dummy_span(),
+                }
+                .with_dummy_span(),
+            ),
+            register.allow_address_overlap.then(|| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("address-overlap"),
+                    expression: Expression::Allow.with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+            register.reset_value.as_ref().map(|reset_value| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("reset"),
+                    expression: match reset_value {
+                        device_driver_generation::mir::ResetValue::Integer(num) => {
+                            Expression::Number(*num as i128)
+                        }
+                        device_driver_generation::mir::ResetValue::Array(items) => {
+                            Expression::ByteArray(items.clone())
+                        }
+                    }
+                    .with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+            Some(
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("fields"),
+                    expression: Expression::SubNode(Box::new(
+                        convert_fieldset(
+                            None,
+                            register.byte_order,
+                            register.bit_order,
+                            register.allow_bit_overlap,
+                            register.size_bits,
+                            &register.fields,
+                        )
+                        .with_message(|| "converting fieldset")?,
+                    ))
+                    .with_dummy_span(),
+                }
+                .with_dummy_span(),
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
+    })
+}
+
+fn convert_command(command: &Command) -> Result<Node<'static>, DynError> {
+    Ok(Node {
+        doc_comments: command
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("command"),
+        name: Ident::new_no_span(command.name.clone().leak()),
+        repeat: command
+            .repeat
+            .map(convert_repeat)
+            .transpose()?
+            .map(SpanExt::with_dummy_span),
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: [
+            Some(
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("address"),
+                    expression: Expression::Number(command.address.into()).with_dummy_span(),
+                }
+                .with_dummy_span(),
+            ),
+            command.allow_address_overlap.then(|| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("address-overlap"),
+                    expression: Expression::Allow.with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+            (!command.in_fields.is_empty())
+                .then(|| {
+                    Ok(Property {
+                        doc_comments: Vec::new(),
+                        name: Ident::new_no_span("fields-in"),
+                        expression: Expression::SubNode(Box::new(
+                            convert_fieldset(
+                                Some(format!("{}FieldsIn", command.name)),
+                                command.byte_order,
+                                command.bit_order,
+                                command.allow_bit_overlap,
+                                command.size_bits_in,
+                                &command.in_fields,
+                            )
+                            .with_message(|| "converting in fieldset")?,
+                        ))
+                        .with_dummy_span(),
+                    }
+                    .with_dummy_span())
+                })
+                .transpose()?,
+            (!command.out_fields.is_empty())
+                .then(|| {
+                    Ok(Property {
+                        doc_comments: Vec::new(),
+                        name: Ident::new_no_span("fields-out"),
+                        expression: Expression::SubNode(Box::new(
+                            convert_fieldset(
+                                Some(format!("{}FieldsOut", command.name)),
+                                command.byte_order,
+                                command.bit_order,
+                                command.allow_bit_overlap,
+                                command.size_bits_out,
+                                &command.out_fields,
+                            )
+                            .with_message(|| "converting out fieldset")?,
+                        ))
+                        .with_dummy_span(),
+                    }
+                    .with_dummy_span())
+                })
+                .transpose()?,
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
+    })
+}
+
+fn convert_fieldset(
+    name: Option<String>,
+    byte_order: Option<V1ByteOrder>,
+    bit_order: BitOrder,
+    allow_bit_overlap: bool,
+    size_bits: u32,
+    fields: &[Field],
+) -> Result<Node<'static>, DynError> {
+    if !size_bits.is_multiple_of(8) {
+        return Err(DynError::new(
+            "size-bits is not a multiple of 8. This is no longer supported in v2",
+        ));
+    }
+    if matches!(bit_order, BitOrder::MSB0) {
+        return Err(DynError::new(
+            "bitorder is MSB0. This is no longer supported in v2 which only supports LSB0",
+        ));
+    }
+
+    Ok(Node {
+        doc_comments: Vec::new(),
+        node_type: Ident::new_no_span("fieldset"),
+        name: Ident::new_no_span(name.map(|name| name.clone().leak() as &str).unwrap_or("_")),
+        repeat: None,
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: [
+            Some(
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("size-bytes"),
+                    expression: Expression::Number((size_bits / 8).into()).with_dummy_span(),
+                }
+                .with_dummy_span(),
+            ),
+            byte_order.map(|byte_order| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("byte-order"),
+                    expression: Expression::ByteOrder(convert_byte_order(byte_order))
+                        .with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+            allow_bit_overlap.then(|| {
+                Property {
+                    doc_comments: Vec::new(),
+                    name: Ident::new_no_span("bit-overlap"),
+                    expression: Expression::Allow.with_dummy_span(),
+                }
+                .with_dummy_span()
+            }),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+        sub_nodes: fields
+            .iter()
+            .map(|f| convert_field(f).with_message(|| format!("converting field {}", f.name)))
+            .collect::<Result<Vec<_>, _>>()?,
+        span: Span::empty(),
+    })
+}
+
+fn convert_field(field: &Field) -> Result<Node<'static>, DynError> {
+    Ok(Node {
+        doc_comments: Vec::new(),
+        node_type: Ident::new_no_span("todo-field"),
+        name: Ident::new_no_span(field.name.clone().leak()),
+        repeat: None,
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: Vec::new(),
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
+    })
+}
+
+fn convert_buffer(buffer: &Buffer) -> Result<Node<'static>, DynError> {
+    Ok(Node {
+        doc_comments: buffer
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("buffer"),
+        name: Ident::new_no_span(buffer.name.clone().leak()),
+        repeat: None,
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: vec![
+            Property {
+                doc_comments: Vec::new(),
+                name: Ident::new_no_span("access"),
+                expression: Expression::Access(convert_access(buffer.access)).with_dummy_span(),
+            }
+            .with_dummy_span(),
+            Property {
+                doc_comments: Vec::new(),
+                name: Ident::new_no_span("address"),
+                expression: Expression::Number(buffer.address.into()).with_dummy_span(),
+            }
+            .with_dummy_span(),
+        ],
+        sub_nodes: Vec::new(),
+        span: Span::empty(),
+    })
+}
+
+fn convert_block(block: &Block) -> Result<Node<'static>, DynError> {
+    Ok(Node {
+        doc_comments: block
+            .description
+            .lines()
+            .map(|l| (l.to_owned().leak() as &str).with_dummy_span())
+            .collect(),
+        node_type: Ident::new_no_span("block"),
+        name: Ident::new_no_span(block.name.clone().leak()),
+        repeat: block
+            .repeat
+            .map(convert_repeat)
+            .transpose()?
+            .map(SpanExt::with_dummy_span),
+        type_specifier: None,
+        short_properties: Vec::new(),
+        properties: vec![
+            Property {
+                doc_comments: Vec::new(),
+                name: Ident::new_no_span("address-offset"),
+                expression: Expression::Number(block.address_offset.into()).with_dummy_span(),
+            }
+            .with_dummy_span(),
+        ],
+        sub_nodes: block
+            .objects
+            .iter()
+            .map(|o| {
+                convert_object(o).with_message(|| format!("converting object {}", object_name(o)))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        span: Span::empty(),
+    })
+}
+
+fn convert_repeat(repeat: V1Repeat) -> Result<Repeat<'static>, DynError> {
+    Ok(Repeat {
+        source: RepeatSource::Count(
+            NonZeroU32::new(
+                u32::try_from(repeat.count).with_message(|| "converting repeat count")?,
+            )
+            .ok_or_else(|| DynError::new("converting repeat count"))?,
+        )
+        .with_dummy_span(),
+        stride: i32::try_from(repeat.stride)
+            .with_message(|| "converting repeat stride")?
+            .with_dummy_span(),
+    })
+}
+
+fn object_name(object: &Object) -> &str {
+    match object {
+        Object::Block(block) => &block.name,
+        Object::Register(register) => &register.name,
+        Object::Command(command) => &command.name,
+        Object::Buffer(buffer) => &buffer.name,
+        Object::Ref(ref_object) => &ref_object.name,
+    }
 }

--- a/compiler/dd-converter/src/lib.rs
+++ b/compiler/dd-converter/src/lib.rs
@@ -30,10 +30,10 @@ pub enum DeviceDriverV1Format {
 /// Don't use in long running programs since conversion may leak memory.
 /// That's because we're running the ddsl parser in reverse while the parser is
 /// optimized for speed and memory use and so usually borrows from the DDSL source.
-pub fn convert(source: &str, format: SourceFormat) -> Result<String, DynError> {
+pub fn convert(_source: &str, format: SourceFormat) -> Result<String, DynError> {
     match format {
         #[cfg(feature = "dd-v1")]
-        SourceFormat::DeviceDriverV1 { sub_format } => dd_v1::convert(source, sub_format)
+        SourceFormat::DeviceDriverV1 { sub_format } => dd_v1::convert(_source, sub_format)
             .with_message(|| format!("converting device-driver v1 format {sub_format:?}")),
     }
 }

--- a/compiler/dd-converter/src/lib.rs
+++ b/compiler/dd-converter/src/lib.rs
@@ -1,0 +1,39 @@
+use device_driver_diagnostics::DynError;
+#[cfg(feature = "dd-v1")]
+use device_driver_diagnostics::ResultExt;
+
+#[cfg(feature = "dd-v1")]
+mod dd_v1;
+
+/// The format to convert into DDSL
+#[derive(Debug, Clone, Copy, clap::Subcommand)]
+pub enum SourceFormat {
+    #[cfg(feature = "dd-v1")]
+    /// The v1 formats of device-driver (DSL, YAML, JSON & TOML)
+    DeviceDriverV1 {
+        #[arg(long)]
+        sub_format: DeviceDriverV1Format,
+    },
+}
+
+#[cfg(feature = "dd-v1")]
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum DeviceDriverV1Format {
+    DSL,
+    YAML,
+    JSON,
+    TOML,
+}
+
+/// Convert the source to ddsl.
+///
+/// Don't use in long running programs since conversion may leak memory.
+/// That's because we're running the ddsl parser in reverse while the parser is
+/// optimized for speed and memory use and so usually borrows from the DDSL source.
+pub fn convert(source: &str, format: SourceFormat) -> Result<String, DynError> {
+    match format {
+        #[cfg(feature = "dd-v1")]
+        SourceFormat::DeviceDriverV1 { sub_format } => dd_v1::convert(source, sub_format)
+            .with_message(|| format!("converting device-driver v1 format {sub_format:?}")),
+    }
+}

--- a/compiler/dd-parser/src/lib.rs
+++ b/compiler/dd-parser/src/lib.rs
@@ -85,7 +85,11 @@ impl<'src> Display for Node<'src> {
                 }
             )?;
         }
-        write!(f, "{indentation}{} {}", self.node_type.val, self.name.val,)?;
+        write!(f, "{indentation}{} {}", self.node_type.val, self.name.val)?;
+
+        if let Some(repeat) = self.repeat {
+            write!(f, "[{} stride {}]", repeat.source, repeat.stride)?;
+        }
 
         for expression in self.short_properties.iter() {
             write!(f, " {}", expression.get_human_string())?;
@@ -341,6 +345,15 @@ pub enum RepeatSource<'src> {
 impl<'src> Default for RepeatSource<'src> {
     fn default() -> Self {
         Self::Count(1.try_into().unwrap())
+    }
+}
+
+impl Display for RepeatSource<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepeatSource::Count(non_zero) => write!(f, "{non_zero}"),
+            RepeatSource::Enum(ident) => write!(f, "{}", ident.val),
+        }
     }
 }
 

--- a/compiler/dd-parser/src/lib.rs
+++ b/compiler/dd-parser/src/lib.rs
@@ -75,7 +75,15 @@ impl<'src> Display for Node<'src> {
         let indentation = format!("{:width$}", "", width = indentation_level * 4);
 
         for doc_comment in &self.doc_comments {
-            writeln!(f, "{indentation}///{doc_comment}")?;
+            writeln!(
+                f,
+                "{indentation}///{}{doc_comment}",
+                if doc_comment.starts_with(" ") {
+                    ""
+                } else {
+                    " "
+                }
+            )?;
         }
         write!(f, "{indentation}{} {}", self.node_type.val, self.name.val,)?;
 
@@ -108,12 +116,26 @@ impl<'src> Display for Node<'src> {
                 for doc_comment in property.doc_comments.iter() {
                     writeln!(f, "{indentation}    ///{}", doc_comment)?;
                 }
-                writeln!(
-                    f,
-                    "{indentation}    {}: {},",
-                    property.name.val,
-                    property.expression.get_human_string()
-                )?;
+
+                write!(f, "{indentation}    {}:", property.name.val)?;
+
+                let expression = property.expression.get_human_string();
+
+                if expression.starts_with("///") {
+                    for line in expression.lines() {
+                        write!(f, "\n{indentation}        {line}")?;
+                    }
+                } else {
+                    for (i, line) in expression.lines().enumerate() {
+                        if i == 0 {
+                            write!(f, " {line}")?;
+                        } else {
+                            write!(f, "\n{indentation}    {line}")?;
+                        }
+                    }
+                }
+
+                writeln!(f, ",")?;
             }
 
             if !self.properties.is_empty() && !self.sub_nodes.is_empty() {

--- a/compiler/dd-parser/src/lib.rs
+++ b/compiler/dd-parser/src/lib.rs
@@ -103,7 +103,17 @@ impl<'src> Display for Node<'src> {
                 match conversion {
                     TypeConversion::Reference(ident) => write!(f, " {}", ident.val)?,
                     TypeConversion::Subnode(node) => {
-                        write!(f, "\n{node:width$}", width = indentation_level + 1)?
+                        if node.doc_comments.is_empty() {
+                            for (i, line) in node.to_string().lines().enumerate() {
+                                if i == 0 {
+                                    write!(f, " {line}")?;
+                                } else {
+                                    write!(f, "\n{indentation}{line}")?;
+                                }
+                            }
+                        } else {
+                            write!(f, "\n{node:width$}", width = indentation_level + 1)?;
+                        }
                     }
                 }
             }
@@ -114,7 +124,16 @@ impl<'src> Display for Node<'src> {
 
             for property in self.properties.iter() {
                 for doc_comment in property.doc_comments.iter() {
-                    writeln!(f, "{indentation}    ///{}", doc_comment)?;
+                    writeln!(
+                        f,
+                        "{indentation}    ///{}{}",
+                        if doc_comment.starts_with(" ") {
+                            ""
+                        } else {
+                            " "
+                        },
+                        doc_comment
+                    )?;
                 }
 
                 write!(f, "{indentation}    {}:", property.name.val)?;


### PR DESCRIPTION
Adds a convert command to the CLI that can ingest v1 manifests and output ddsl.
Closes #116 

Todo:
- [x] Write migrations guide
- [x] Document the limitations of the converter
  - Ref blocks don't exist anymore and are now simply copies that will need hand work. Maybe suggest enum repeats?
  - Ref commands and registers create new full commands and registers, but with reused fieldsets
  - Cfgs are ignored as they don't exist in v2
  - Converter generates more explicit code than is required (think writing bool and uint, or writing RW everywhere)
  - All numbers are decimal even if originally specified as hex (maybe that's a todo? People should be able to specify?)
  - All non-enum conversions are now type references. If in v1 they pointed to a Rust type, you'll have to define an extern ddsl type manually
  - Name uniqueness has been restricted. Two types can't have the same name anymore and you might find errors about that