### PR TITLE
Mandatory access

### DIFF
--- a/book/src/gen-docs/mir-shapes/block.md
+++ b/book/src/gen-docs/mir-shapes/block.md
@@ -2,8 +2,9 @@
 
 ```ddsl
 /// doc comment line
-block Example {
+block Example[8 stride 4] {
     address-offset: 0,
+    default-access: RW,
 
     block node,
     register node,
@@ -37,6 +38,16 @@ address-offset: 0
 ```
 #### Info
 - required: `yes`
+- multiple allowed: `no`
+- supports doc comments: `no`
+### default-access
+When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore
+```ddsl
+// access specifier
+default-access: RW
+```
+#### Info
+- required: `no`
 - multiple allowed: `no`
 - supports doc comments: `no`
 ## Possible subnodes

--- a/book/src/gen-docs/mir-shapes/buffer.md
+++ b/book/src/gen-docs/mir-shapes/buffer.md
@@ -21,7 +21,7 @@ buffer Example {
 ## Long properties
 These properties are specified in the node body.
 ### access
-Limits how the buffer can be accessed. If not specified, the access is `RW`.
+Limits how the buffer can be accessed. Must be specified unless a `default-access` is set by a parent object.
 ```ddsl
 // access specifier
 access: RW

--- a/book/src/gen-docs/mir-shapes/command.md
+++ b/book/src/gen-docs/mir-shapes/command.md
@@ -2,7 +2,7 @@
 
 ```ddsl
 /// doc comment line
-command Example {
+command Example[8 stride 4] {
     address: 0,
     address-overlap: allow,
     fields-in: MyFieldset,

--- a/book/src/gen-docs/mir-shapes/device.md
+++ b/book/src/gen-docs/mir-shapes/device.md
@@ -9,6 +9,7 @@ device Example {
     buffer-address-type: i32,
     word-boundaries: "bD:0B:_",
     register-address-mode: mapped,
+    default-access: RW,
 
     block node,
     register node,
@@ -103,6 +104,16 @@ If this value is specified, then it permits bulk register reads and writes.
 ```ddsl
 // address mode
 register-address-mode: mapped
+```
+#### Info
+- required: `no`
+- multiple allowed: `no`
+- supports doc comments: `no`
+### default-access
+When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore
+```ddsl
+// access specifier
+default-access: RW
 ```
 #### Info
 - required: `no`

--- a/book/src/gen-docs/mir-shapes/field.md
+++ b/book/src/gen-docs/mir-shapes/field.md
@@ -2,7 +2,7 @@
 
 ```ddsl
 /// doc comment line
-field Example 8:0 RW -> uint as try Foo
+field Example[8 stride 4] 8:0 RW -> uint as try Foo
 ```
 ## Table
 
@@ -30,7 +30,7 @@ address: 0
 - multiple allowed: `no`
 - supports doc comments: `no`
 ### access
-Limits how the field can be accessed. If not specified, the access is `RW`.
+Limits how the field can be accessed. Must be specified unless a `default-access` is set by a parent object.
 ```ddsl
 // access specifier
 access: RW

--- a/book/src/gen-docs/mir-shapes/fieldset.md
+++ b/book/src/gen-docs/mir-shapes/fieldset.md
@@ -6,6 +6,7 @@ fieldset Example {
     size-bytes: 8,
     byte-order: LE,
     bit-overlap: allow,
+    default-access: RW,
 
     field node,
 }
@@ -48,6 +49,16 @@ Allows fields to overlap. This is not allowed by default to prevent copy-paste m
 ```ddsl
 // allow
 bit-overlap: allow
+```
+#### Info
+- required: `no`
+- multiple allowed: `no`
+- supports doc comments: `no`
+### default-access
+When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore
+```ddsl
+// access specifier
+default-access: RW
 ```
 #### Info
 - required: `no`

--- a/book/src/gen-docs/mir-shapes/manifest.md
+++ b/book/src/gen-docs/mir-shapes/manifest.md
@@ -9,6 +9,7 @@ manifest Example {
     buffer-address-type: i32,
     word-boundaries: "bD:0B:_",
     register-address-mode: mapped,
+    default-access: RW,
 
     device node,
     fieldset node,
@@ -100,6 +101,16 @@ If this value is specified, then it permits bulk register reads and writes.
 ```ddsl
 // address mode
 register-address-mode: mapped
+```
+#### Info
+- required: `no`
+- multiple allowed: `no`
+- supports doc comments: `no`
+### default-access
+When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore
+```ddsl
+// access specifier
+default-access: RW
 ```
 #### Info
 - required: `no`

--- a/book/src/gen-docs/mir-shapes/register.md
+++ b/book/src/gen-docs/mir-shapes/register.md
@@ -2,7 +2,7 @@
 
 ```ddsl
 /// doc comment line
-register Example {
+register Example[8 stride 4] {
     address: 0,
     access: RW,
     address-overlap: allow,
@@ -34,7 +34,7 @@ address: 0
 - multiple allowed: `no`
 - supports doc comments: `no`
 ### access
-Limits how the register can be accessed. If not specified, the access is `RW`.
+Limits how the register can be accessed. Must be specified unless a `default-access` is set by a parent object.
 ```ddsl
 // access specifier
 access: RW

--- a/book/src/v2/tutorial-ym3812.md
+++ b/book/src/v2/tutorial-ym3812.md
@@ -92,7 +92,11 @@ First we create a file named `ym3812.ddsl` (or something else to your liking). T
 
 ```ddsl
 device Ym3812 {
+    // Our register address space is 0-255, and the shift register takes a byte,
+    // so use u8 for the address type
     register-address-type: u8,
+    // Everything is read-write, so to save some typing, we set a default
+    default-access: RW,
 }
 ```
 
@@ -116,6 +120,7 @@ Let's define them in ddsl:
 ```ddsl
 device Ym3812 {
     register-address-type: u8,
+    default-access: RW,
 
     /// Register containing the Waveform Select Enable and some test fields
     register Enable_waveform_control {

--- a/compiler/dd-common/src/span.rs
+++ b/compiler/dd-common/src/span.rs
@@ -15,7 +15,7 @@ impl Span {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.start >= self.end
+        self.start == 0 && self.end == 0
     }
 
     /// Return self if not empty, or the other span if self is empty
@@ -52,6 +52,15 @@ impl Span {
         assert!(start.start <= self.end);
         Self {
             start: start.start,
+            end: self.end,
+        }
+    }
+
+    /// Discard the span and keep a zero-length span at the end value
+    #[must_use]
+    pub fn collapse_to_end(&self) -> Span {
+        Span {
+            start: self.end,
             end: self.end,
         }
     }

--- a/compiler/dd-diagnostics/src/errors.rs
+++ b/compiler/dd-diagnostics/src/errors.rs
@@ -847,7 +847,7 @@ impl Diagnostic for ConversionTypeTooBig {
 #[derive(Debug)]
 pub struct UnspecifiedByteOrder {
     pub fieldset_name: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
 }
 
 impl Diagnostic for UnspecifiedByteOrder {
@@ -869,8 +869,10 @@ impl Diagnostic for UnspecifiedByteOrder {
             Level::HELP.secondary_title(
                 "specify the byte order on the fieldset or add a default byte order on the device",
             )
-            .element(Snippet::source(source).path(path).patch(
-                Patch::new(self.properties_span.start..self.properties_span.start, "byte-order: LE,\n")
+            .elements( self.properties_span.map(|properties_span| {
+                Snippet::source(source).path(path).patch(
+                    Patch::new(properties_span.start..properties_span.start, "byte-order: LE,\n")
+                )}
             )),
             Group::with_title(Level::NOTE.secondary_title(
                 "the fieldset spans multiple bytes, so it needs to have byte ordering specified",
@@ -887,7 +889,7 @@ impl Diagnostic for UnspecifiedByteOrder {
 pub struct UnspecifiedAccess {
     pub object_name: Span,
     pub short_property: bool,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
 }
 
 impl Diagnostic for UnspecifiedAccess {
@@ -908,18 +910,20 @@ impl Diagnostic for UnspecifiedAccess {
                 .secondary_title(
                     "specify the access on the object or add a `default-access` to a parent object",
                 )
-                .element(Snippet::source(source).path(path).patch(Patch::new(
-                    if self.short_property {
-                        self.properties_span.end..self.properties_span.end
-                    } else {
-                        self.properties_span.start..self.properties_span.start
-                    },
-                    if self.short_property {
-                        " RW"
-                    } else {
-                        "access: RW,\n"
-                    },
-                ))),
+                .elements(self.properties_span.map(|properties_span| {
+                    Snippet::source(source).path(path).patch(Patch::new(
+                        if self.short_property {
+                            properties_span.end..properties_span.end
+                        } else {
+                            properties_span.start..properties_span.start
+                        },
+                        if self.short_property {
+                            " RW"
+                        } else {
+                            "access: RW,\n"
+                        },
+                    ))
+                })),
         ]
         .to_vec()
     }
@@ -1222,7 +1226,7 @@ impl Diagnostic for OverlappingFields {
 pub struct AddressTypeUndefined {
     pub object_name: Span,
     pub device: Span,
-    pub device_config_area: Span,
+    pub properties_span: Option<Span>,
     pub object_type: &'static str,
 }
 
@@ -1254,10 +1258,12 @@ impl Diagnostic for AddressTypeUndefined {
             ),
             Level::HELP.secondary_title(
                 "add the address type as a global default or as config on the device the object is defined in"
-            ).element(
-                Snippet::source(source).path(path).patch(
-                    Patch::new(self.device_config_area.start..self.device_config_area.start, format!("{}-address-type: u16\n", self.object_type))
-                )
+            ).elements(
+                self.properties_span.map(|properties_span| {
+                    Snippet::source(source).path(path).patch(
+                        Patch::new(properties_span.start..properties_span.start, format!("{}-address-type: u16\n", self.object_type))
+                    )
+                })
             ),
             Group::with_title(
                 Level::INFO.secondary_title("device-driver is agnostic to the address types being used. As such, it must be manually specified")
@@ -1731,6 +1737,8 @@ pub struct MissingRequiredProperty {
     pub property_name: String,
     pub short: bool,
     pub allowed_property_types: Vec<String>,
+    pub example_values: Vec<Cow<'static, str>>,
+    pub properties_span: Option<Span>,
 }
 
 impl Diagnostic for MissingRequiredProperty {
@@ -1753,20 +1761,36 @@ impl Diagnostic for MissingRequiredProperty {
             )
         };
 
-        [
-            Level::ERROR
-                .primary_title(format!(
-                    "{} node is missing a required property",
-                    self.node_type
-                ))
-                .element(
-                    Snippet::source(source).path(path).annotation(
-                        AnnotationKind::Primary
-                            .span(self.node_type.span.into())
-                            .label(label),
-                    ),
-                ), // TODO: Add patches to show user adding the properties
-        ]
+        [Level::ERROR
+            .primary_title(format!(
+                "{} node is missing a required property",
+                self.node_type
+            ))
+            .element(
+                Snippet::source(source).path(path).annotation(
+                    AnnotationKind::Primary
+                        .span(self.node_type.span.into())
+                        .label(label),
+                ),
+            )
+            .elements(self.properties_span.map(|properties_span| {
+                Snippet::source(source)
+                    .path(path)
+                    .patches(self.example_values.iter().map(|example_value| {
+                        Patch::new(
+                            if self.short {
+                                properties_span.end..properties_span.end
+                            } else {
+                                properties_span.start..properties_span.start
+                            },
+                            if self.short {
+                                format!(" {example_value}")
+                            } else {
+                                format!("{}: {example_value},\n", self.property_name)
+                            },
+                        )
+                    }))
+            }))]
         .to_vec()
     }
 }

--- a/compiler/dd-diagnostics/src/errors.rs
+++ b/compiler/dd-diagnostics/src/errors.rs
@@ -847,6 +847,7 @@ impl Diagnostic for ConversionTypeTooBig {
 #[derive(Debug)]
 pub struct UnspecifiedByteOrder {
     pub fieldset_name: Span,
+    pub properties_span: Span,
 }
 
 impl Diagnostic for UnspecifiedByteOrder {
@@ -865,15 +866,60 @@ impl Diagnostic for UnspecifiedByteOrder {
                             .label("fieldset requires a byte order, but none is specified"),
                     ),
                 ),
-            Group::with_title(Level::HELP.secondary_title(
+            Level::HELP.secondary_title(
                 "specify the byte order on the fieldset or add a default byte order on the device",
-            )), // TODO: Add patch for adding byte order
+            )
+            .element(Snippet::source(source).path(path).patch(
+                Patch::new(self.properties_span.start..self.properties_span.start, "byte-order: LE,\n")
+            )),
             Group::with_title(Level::NOTE.secondary_title(
                 "the fieldset spans multiple bytes, so it needs to have byte ordering specified",
             )),
             Group::with_title(Level::INFO.secondary_title(
                 "byte order is important for any multi-byte value. It has no default, so it needs to be manually specified",
             )),
+        ]
+        .to_vec()
+    }
+}
+
+#[derive(Debug)]
+pub struct UnspecifiedAccess {
+    pub object_name: Span,
+    pub short_property: bool,
+    pub properties_span: Span,
+}
+
+impl Diagnostic for UnspecifiedAccess {
+    fn is_error(&self) -> bool {
+        true
+    }
+
+    fn as_report<'a>(&'a self, source: &'a str, path: &'a str) -> Vec<Group<'a>> {
+        [
+            Level::ERROR.primary_title("unspecified access").element(
+                Snippet::source(source).path(path).annotation(
+                    AnnotationKind::Primary
+                        .span(self.object_name.into())
+                        .label("object requires an access to be specified, but none is"),
+                ),
+            ),
+            Level::HELP
+                .secondary_title(
+                    "specify the access on the object or add a `default-access` to a parent object",
+                )
+                .element(Snippet::source(source).path(path).patch(Patch::new(
+                    if self.short_property {
+                        self.properties_span.end..self.properties_span.end
+                    } else {
+                        self.properties_span.start..self.properties_span.start
+                    },
+                    if self.short_property {
+                        " RW"
+                    } else {
+                        "access: RW,\n"
+                    },
+                ))),
         ]
         .to_vec()
     }

--- a/compiler/dd-lir/src/lowering.rs
+++ b/compiler/dd-lir/src/lowering.rs
@@ -164,7 +164,7 @@ fn get_method(
                 repeat: repeat_to_method_kind(repeat, manifest),
                 method_type: lir::BlockMethodType::Register {
                     field_set_name: field_set.name().clone().cast_assert(),
-                    access: *access,
+                    access: access.ok_or_else(|| DynError::new("access is not set"))?,
                     reset_value: reset_value.as_ref().map(|rv| {
                         rv.as_array().cloned().map(|array| array.with_span(rv.span)).ok_or_else(
                             || DynError::new("reset value is not an array while it should have been converted to array a mir pass"),
@@ -219,13 +219,17 @@ fn get_method(
             name,
             access,
             address,
+            short_properties_span: _,
+            properties_span: _,
             span: _,
         }) => Some(lir::BlockMethod {
             description: description.clone(),
             name: name.value.clone(),
             address: address.value,
             repeat: lir::Repeat::None, // Buffers can't be repeated (for now?)
-            method_type: lir::BlockMethodType::Buffer { access: *access },
+            method_type: lir::BlockMethodType::Buffer {
+                access: access.ok_or_else(|| DynError::new("access is not set"))?,
+            },
         }),
         mir::Object::FieldSet(_) => None,
         mir::Object::Enum(_) => None,
@@ -286,6 +290,8 @@ fn transform_field(manifest: &mir::Manifest, field: &mir::Field) -> Result<lir::
         field_conversion,
         field_address,
         repeat,
+        short_properties_span: _,
+        properties_span: _,
         span: _,
     } = field;
 
@@ -356,7 +362,7 @@ fn transform_field(manifest: &mir::Manifest, field: &mir::Field) -> Result<lir::
         address: field_address.value,
         base_type,
         conversion_method,
-        access: *access,
+        access: access.ok_or_else(|| DynError::new("access is not set"))?,
         repeat: repeat_to_method_kind(repeat, manifest),
     })
 }
@@ -370,6 +376,8 @@ pub fn transform_enums(manifest: &mir::Manifest) -> Vec<lir::Enum> {
             base_type,
             size_bits: _,
             generation_style: _,
+            short_properties_span: _,
+            properties_span: _,
             span: _
         } = e;
 
@@ -469,6 +477,9 @@ impl<'o> From<&'o mir::Block> for BorrowedBlock<'o> {
             address_offset,
             repeat,
             objects,
+            default_access: _,
+            short_properties_span: _,
+            properties_span: _,
             span: _,
         } = value;
 

--- a/compiler/dd-mir/src/lowering/mod.rs
+++ b/compiler/dd-mir/src/lowering/mod.rs
@@ -282,7 +282,12 @@ fn parse_node_to_shape<'src, S: Shape>(
     let mut removed_properties = HashMap::new();
     let mut removed_short_properties = HashMap::new();
     for property in &node.properties {
-        *target.properties_span() = target.properties_span().or(property.span).to(property.span);
+        *target.properties_span() = Some(
+            target
+                .properties_span()
+                .unwrap_or(property.span)
+                .to(property.span),
+        );
 
         let Some(property_info) = possible_properties
             .iter()
@@ -372,9 +377,19 @@ fn parse_node_to_shape<'src, S: Shape>(
             removed_properties.insert(property.name.val, property.name.span);
         }
     }
+    if target.properties_span().is_none() {
+        *target.properties_span() = node
+            .sub_nodes
+            .iter()
+            .map(|n| n.span)
+            .reduce(|acc, val| acc.to(val));
+    }
 
     for short_property in node.short_properties.iter() {
-        *target.short_properties_span() = target.short_properties_span().or(short_property.span).to(short_property.span);
+        *target.short_properties_span() = target
+            .short_properties_span()
+            .or(short_property.span)
+            .to(short_property.span);
 
         let short_property_discriminant = discriminant(&short_property.value);
 
@@ -437,6 +452,14 @@ fn parse_node_to_shape<'src, S: Shape>(
             possible_properties.remove(possible_properties.element_offset(property_info).unwrap());
         }
     }
+    if target.short_properties_span().is_empty() {
+        *target.short_properties_span() = node
+            .repeat
+            .map(|r| r.span)
+            .unwrap_or_default()
+            .or(node.name.span)
+            .collapse_to_end();
+    }
 
     // Required properties that haven't been seen
     let missing_properties = possible_properties
@@ -446,6 +469,7 @@ fn parse_node_to_shape<'src, S: Shape>(
 
     if !missing_properties.is_empty() {
         for missing_info in missing_properties {
+            let short = matches!(missing_info.name, PropertyName::Short(_));
             diagnostics.add(MissingRequiredProperty {
                 node_type: S::NODE_TYPE.with_span(node.node_type.span),
                 property_name: match missing_info.name {
@@ -453,12 +477,22 @@ fn parse_node_to_shape<'src, S: Shape>(
                     PropertyName::Short(val) => val.to_string(),
                     _ => "*".to_string(),
                 },
-                short: matches!(missing_info.name, PropertyName::Short(_)),
+                short,
                 allowed_property_types: missing_info
                     .allowed_expression_types
                     .iter()
                     .map(|e| e.to_string())
                     .collect(),
+                example_values: missing_info
+                    .allowed_expression_types
+                    .iter()
+                    .map(|e| e.get_human_string())
+                    .collect(),
+                properties_span: if short {
+                    Some(*target.short_properties_span())
+                } else {
+                    *target.properties_span()
+                },
             });
         }
         error = true;
@@ -541,7 +575,7 @@ trait Shape: Default + 'static {
         None
     }
 
-    fn properties_span(&mut self) -> &mut Span;
+    fn properties_span(&mut self) -> &mut Option<Span>;
     fn short_properties_span(&mut self) -> &mut Span;
     fn span(&mut self) -> &mut Span;
 }

--- a/compiler/dd-mir/src/lowering/mod.rs
+++ b/compiler/dd-mir/src/lowering/mod.rs
@@ -282,6 +282,8 @@ fn parse_node_to_shape<'src, S: Shape>(
     let mut removed_properties = HashMap::new();
     let mut removed_short_properties = HashMap::new();
     for property in &node.properties {
+        *target.properties_span() = target.properties_span().or(property.span).to(property.span);
+
         let Some(property_info) = possible_properties
             .iter()
             .find(|p| p.name == PropertyName::Exact(property.name.val))
@@ -372,6 +374,8 @@ fn parse_node_to_shape<'src, S: Shape>(
     }
 
     for short_property in node.short_properties.iter() {
+        *target.short_properties_span() = target.short_properties_span().or(short_property.span).to(short_property.span);
+
         let short_property_discriminant = discriminant(&short_property.value);
 
         let Some(property_info) = possible_properties.iter().find(|p| {
@@ -537,6 +541,8 @@ trait Shape: Default + 'static {
         None
     }
 
+    fn properties_span(&mut self) -> &mut Span;
+    fn short_properties_span(&mut self) -> &mut Span;
     fn span(&mut self) -> &mut Span;
 }
 

--- a/compiler/dd-mir/src/lowering/shape_impls.rs
+++ b/compiler/dd-mir/src/lowering/shape_impls.rs
@@ -227,11 +227,11 @@ If this value is specified, then it permits bulk register reads and writes.",
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -433,11 +433,11 @@ If this value is specified, then it permits bulk register reads and writes.",
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -523,11 +523,11 @@ If this is not desired, then keep the address offset at 0.",
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -714,11 +714,11 @@ The value can be expressed in two ways:
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -831,11 +831,11 @@ impl Shape for FieldSet {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -910,11 +910,11 @@ impl Shape for Extern {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -977,11 +977,11 @@ impl Shape for Buffer {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -1058,11 +1058,11 @@ impl Shape for Enum {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -1251,11 +1251,11 @@ impl Shape for Command {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }
@@ -1362,11 +1362,11 @@ impl Shape for Field {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
-    
-    fn properties_span(&mut self) -> &mut Span {
+
+    fn properties_span(&mut self) -> &mut Option<Span> {
         &mut self.properties_span
     }
-    
+
     fn short_properties_span(&mut self) -> &mut Span {
         &mut self.short_properties_span
     }

--- a/compiler/dd-mir/src/lowering/shape_impls.rs
+++ b/compiler/dd-mir/src/lowering/shape_impls.rs
@@ -191,6 +191,22 @@ If this value is specified, then it permits bulk register reads and writes.",
                     false
                 },
             },
+            PropertyInfo {
+                name: PropertyName::Exact("default-access"),
+                description: "When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore",
+                allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
+                multiple_allowed: false,
+                required: false,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                             target_object,
+                             property,
+                             ..
+                         }| {
+                    target_object.default_access = Some(property.expression.as_access().unwrap());
+                    false
+                },
+            },
         ];
         MAP
     }
@@ -210,6 +226,14 @@ If this value is specified, then it permits bulk register reads and writes.",
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }
 
@@ -370,6 +394,22 @@ If this value is specified, then it permits bulk register reads and writes.",
                     false
                 },
             },
+            PropertyInfo {
+                name: PropertyName::Exact("default-access"),
+                description: "When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore",
+                allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
+                multiple_allowed: false,
+                required: false,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                             target_object,
+                             property,
+                             ..
+                         }| {
+                    target_object.default_access = Some(property.expression.as_access().unwrap());
+                    false
+                },
+            },
         ];
         MAP
     }
@@ -393,6 +433,14 @@ If this value is specified, then it permits bulk register reads and writes.",
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
+    }
 }
 
 impl Shape for Block {
@@ -408,29 +456,47 @@ impl Shape for Block {
     }
 
     fn supported_properties() -> &'static [PropertyInfo<Self>] {
-        static MAP: &[PropertyInfo<Block>] = &[PropertyInfo {
-            name: PropertyName::Exact("address-offset"),
-            description: "\
+        static MAP: &[PropertyInfo<Block>] = &[
+            PropertyInfo {
+                name: PropertyName::Exact("address-offset"),
+                description: "\
 Defines the address offset of this block. All objects in the block are relative to the block.
 For example, a block with an address offset of 10 which has a register at address 5, will have defined the register at address 15.
 If this is not desired, then keep the address offset at 0.",
-            allowed_expression_types: Cow::Borrowed(&[Expression::Number(0)]),
-            multiple_allowed: false,
-            required: true,
-            supports_doc_comments: false,
-            setter: |SetterArgs {
-                         target_object: block,
-                         property,
-                         ..
-                     }| {
-                block.address_offset = property
-                    .expression
-                    .as_number()
-                    .unwrap()
-                    .with_span(property.expression.span);
-                false
+                allowed_expression_types: Cow::Borrowed(&[Expression::Number(0)]),
+                multiple_allowed: false,
+                required: true,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                            target_object: block,
+                            property,
+                            ..
+                        }| {
+                    block.address_offset = property
+                        .expression
+                        .as_number()
+                        .unwrap()
+                        .with_span(property.expression.span);
+                    false
+                },
             },
-        }];
+            PropertyInfo {
+                name: PropertyName::Exact("default-access"),
+                description: "When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore",
+                allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
+                multiple_allowed: false,
+                required: false,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                             target_object,
+                             property,
+                             ..
+                         }| {
+                    target_object.default_access = Some(property.expression.as_access().unwrap());
+                    false
+                },
+            },
+        ];
         MAP
     }
 
@@ -456,6 +522,14 @@ If this is not desired, then keep the address offset at 0.",
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }
 
@@ -496,7 +570,7 @@ impl Shape for Register {
                 },
                 PropertyInfo {
                     name: PropertyName::Exact("access"),
-                    description: "Limits how the register can be accessed. If not specified, the access is `RW`.",
+                    description: "Limits how the register can be accessed. Must be specified unless a `default-access` is set by a parent object.",
                     allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
                     multiple_allowed: false,
                     required: false,
@@ -506,7 +580,7 @@ impl Shape for Register {
                                  property,
                                  ..
                              }| {
-                        r.access = property.expression.as_access().unwrap();
+                        r.access = Some(property.expression.as_access().unwrap());
                         false
                     },
                 },
@@ -640,6 +714,14 @@ The value can be expressed in two ways:
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
+    }
 }
 
 impl Shape for FieldSet {
@@ -715,6 +797,22 @@ impl Shape for FieldSet {
                     false
                 },
             },
+            PropertyInfo {
+                name: PropertyName::Exact("default-access"),
+                description: "When set, all subobjects use this value as their access value (unless overridden) and don't require an access specifier anymore",
+                allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
+                multiple_allowed: false,
+                required: false,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                             target_object,
+                             property,
+                             ..
+                         }| {
+                    target_object.default_access = Some(property.expression.as_access().unwrap());
+                    false
+                },
+            },
         ];
         MAP
     }
@@ -732,6 +830,14 @@ impl Shape for FieldSet {
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }
 
@@ -804,6 +910,14 @@ impl Shape for Extern {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
+    }
 }
 
 impl Shape for Buffer {
@@ -822,7 +936,7 @@ impl Shape for Buffer {
         static MAP: &[PropertyInfo<Buffer>] = &[
             PropertyInfo {
                 name: PropertyName::Exact("access"),
-                description: "Limits how the buffer can be accessed. If not specified, the access is `RW`.",
+                description: "Limits how the buffer can be accessed. Must be specified unless a `default-access` is set by a parent object.",
                 allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
                 multiple_allowed: false,
                 required: false,
@@ -832,7 +946,7 @@ impl Shape for Buffer {
                              property,
                              ..
                          }| {
-                    buf.access = property.expression.as_access().unwrap();
+                    buf.access = Some(property.expression.as_access().unwrap());
                     false
                 },
             },
@@ -862,6 +976,14 @@ impl Shape for Buffer {
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }
 
@@ -935,6 +1057,14 @@ impl Shape for Enum {
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }
 
@@ -1121,6 +1251,14 @@ impl Shape for Command {
     fn span(&mut self) -> &mut Span {
         &mut self.span
     }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
+    }
 }
 
 impl Shape for Field {
@@ -1191,7 +1329,7 @@ impl Shape for Field {
             },
             PropertyInfo {
                 name: PropertyName::Short("access"),
-                description: "Limits how the field can be accessed. If not specified, the access is `RW`.",
+                description: "Limits how the field can be accessed. Must be specified unless a `default-access` is set by a parent object.",
                 allowed_expression_types: Cow::Borrowed(&[Expression::Access(Access::RW)]),
                 multiple_allowed: false,
                 required: false,
@@ -1201,7 +1339,7 @@ impl Shape for Field {
                              property,
                              ..
                          }| {
-                    field.access = property.expression.as_access().unwrap();
+                    field.access = Some(property.expression.as_access().unwrap());
                     false
                 },
             },
@@ -1223,5 +1361,13 @@ impl Shape for Field {
 
     fn span(&mut self) -> &mut Span {
         &mut self.span
+    }
+    
+    fn properties_span(&mut self) -> &mut Span {
+        &mut self.properties_span
+    }
+    
+    fn short_properties_span(&mut self) -> &mut Span {
+        &mut self.short_properties_span
     }
 }

--- a/compiler/dd-mir/src/model.rs
+++ b/compiler/dd-mir/src/model.rs
@@ -21,7 +21,7 @@ pub struct Manifest {
     pub objects: Vec<Object>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     pub span: Span,
 }
 
@@ -255,7 +255,7 @@ pub struct Device {
     pub objects: Vec<Object>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -523,6 +523,20 @@ impl Object {
             Object::Field(_) => Vec::new(),
         }
     }
+
+    pub fn properties_span(&self) -> Option<Span> {
+        match self {
+            Object::Device(val) => val.properties_span,
+            Object::Block(val) => val.properties_span,
+            Object::Register(val) => val.properties_span,
+            Object::Command(val) => val.properties_span,
+            Object::Buffer(val) => val.properties_span,
+            Object::FieldSet(val) => val.properties_span,
+            Object::Enum(val) => val.properties_span,
+            Object::Extern(val) => val.properties_span,
+            Object::Field(val) => val.properties_span,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -535,7 +549,7 @@ pub struct Block {
     pub default_access: Option<Access>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -565,7 +579,7 @@ pub struct Register {
     pub field_set_ref: Spanned<IdentifierRef<Type>>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -581,7 +595,7 @@ pub struct FieldSet {
     pub fields: Vec<Field>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -603,7 +617,7 @@ pub struct Field {
     pub repeat: Option<Repeat>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -635,7 +649,7 @@ pub struct Enum {
     pub generation_style: Option<EnumGenerationStyle>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -658,7 +672,7 @@ impl Enum {
             size_bits,
             generation_style: None,
             short_properties_span: Span::empty(),
-            properties_span: Span::empty(),
+            properties_span: None,
             span,
         }
     }
@@ -681,7 +695,7 @@ impl Enum {
             size_bits,
             generation_style: Some(generation_style),
             short_properties_span: Span::empty(),
-            properties_span: Span::empty(),
+            properties_span: None,
             span,
         }
     }
@@ -805,7 +819,7 @@ pub struct Command {
     pub field_set_ref_out: Option<Spanned<IdentifierRef<Type>>>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -818,7 +832,7 @@ pub struct Buffer {
     pub address: Spanned<i128>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }
@@ -835,7 +849,7 @@ pub struct Extern {
     pub size_bits: Option<Spanned<u64>>,
 
     pub short_properties_span: Span,
-    pub properties_span: Span,
+    pub properties_span: Option<Span>,
     /// Span of the whole object
     pub span: Span,
 }

--- a/compiler/dd-mir/src/model.rs
+++ b/compiler/dd-mir/src/model.rs
@@ -16,8 +16,12 @@ use device_driver_common::{
 pub struct Manifest {
     pub description: String,
     pub name: Spanned<Identifier<All>>,
+    pub default_access: Option<Access>,
     pub config: DeviceConfig,
     pub objects: Vec<Object>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     pub span: Span,
 }
 
@@ -222,6 +226,8 @@ impl<'a> Iterator for ObjectIter<'a> {
 /// Implementation meant for testing to easily create a manifest with just one device
 impl From<Device> for Manifest {
     fn from(value: Device) -> Self {
+        let default_access = value.default_access;
+
         Self {
             description: String::new(),
             name: value
@@ -230,8 +236,11 @@ impl From<Device> for Manifest {
                 .clone()
                 .cast_unchecked()
                 .with_span(value.name.span),
+            short_properties_span: value.short_properties_span,
+            properties_span: value.properties_span,
             span: value.span,
             objects: vec![Object::Device(value)],
+            default_access,
             config: DeviceConfig::default(),
         }
     }
@@ -241,8 +250,12 @@ impl From<Device> for Manifest {
 pub struct Device {
     pub description: String,
     pub name: Spanned<Identifier<Type>>,
+    pub default_access: Option<Access>,
     pub device_config: DeviceConfig,
     pub objects: Vec<Object>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -305,14 +318,14 @@ pub enum Object {
 }
 
 impl Object {
-    pub(crate) fn device_config(&self) -> Option<&DeviceConfig> {
+    pub fn device_config(&self) -> Option<&DeviceConfig> {
         match self {
             Object::Device(device) => Some(&device.device_config),
             _ => None,
         }
     }
 
-    pub(crate) fn child_objects_mut(&mut self) -> &mut [Object] {
+    pub fn child_objects_mut(&mut self) -> &mut [Object] {
         match self {
             Object::Device(device) => &mut device.objects,
             Object::Block(block) => &mut block.objects,
@@ -320,7 +333,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn child_objects_vec(&mut self) -> Option<&mut Vec<Object>> {
+    pub fn child_objects_vec(&mut self) -> Option<&mut Vec<Object>> {
         match self {
             Object::Device(device) => Some(&mut device.objects),
             Object::Block(block) => Some(&mut block.objects),
@@ -328,7 +341,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn child_objects(&self) -> &[Object] {
+    pub fn child_objects(&self) -> &[Object] {
         match self {
             Object::Device(device) => &device.objects,
             Object::Block(block) => &block.objects,
@@ -337,7 +350,7 @@ impl Object {
     }
 
     /// Get a mutable reference to the name of the specific object
-    pub(crate) fn name_mut(&mut self) -> &mut Identifier<RuntimeType> {
+    pub fn name_mut(&mut self) -> &mut Identifier<RuntimeType> {
         match self {
             Object::Device(val) => val.name.as_runtime_type_mut(),
             Object::Block(val) => val.name.as_runtime_type_mut(),
@@ -367,7 +380,7 @@ impl Object {
     }
 
     /// Get the span of the name of the object
-    pub(crate) fn name_span(&self) -> Span {
+    pub fn name_span(&self) -> Span {
         match self {
             Object::Device(val) => val.name.span,
             Object::Block(val) => val.name.span,
@@ -382,7 +395,7 @@ impl Object {
     }
 
     /// Return the address if it is specified.
-    pub(crate) fn address(&self) -> Option<Spanned<i128>> {
+    pub fn address(&self) -> Option<Spanned<i128>> {
         match self {
             Object::Device(_) => None,
             Object::Block(block) => Some(block.address_offset),
@@ -397,7 +410,7 @@ impl Object {
     }
 
     /// Return the repeat value if it exists
-    pub(crate) fn repeat(&self) -> Option<&Repeat> {
+    pub fn repeat(&self) -> Option<&Repeat> {
         match self {
             Object::Device(_) => None,
             Object::Block(block) => block.repeat.as_ref(),
@@ -412,7 +425,7 @@ impl Object {
     }
 
     /// Return the repeat value if it exists
-    pub(crate) fn repeat_mut(&mut self) -> Option<&mut Repeat> {
+    pub fn repeat_mut(&mut self) -> Option<&mut Repeat> {
         match self {
             Object::Device(_) => None,
             Object::Block(block) => block.repeat.as_mut(),
@@ -426,7 +439,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn as_field_set(&self) -> Option<&FieldSet> {
+    pub fn as_field_set(&self) -> Option<&FieldSet> {
         if let Self::FieldSet(v) = self {
             Some(v)
         } else {
@@ -434,7 +447,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn as_field_set_mut(&mut self) -> Option<&mut FieldSet> {
+    pub fn as_field_set_mut(&mut self) -> Option<&mut FieldSet> {
         if let Self::FieldSet(v) = self {
             Some(v)
         } else {
@@ -450,7 +463,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn allow_address_overlap(&self) -> bool {
+    pub fn allow_address_overlap(&self) -> bool {
         match self {
             Object::Device(_) => false,
             Object::Block(_) => false,
@@ -465,7 +478,7 @@ impl Object {
     }
 
     /// The span of the entire object
-    pub(crate) fn span(&self) -> Span {
+    pub fn span(&self) -> Span {
         match self {
             Object::Device(val) => val.span,
             Object::Block(val) => val.span,
@@ -479,7 +492,7 @@ impl Object {
         }
     }
 
-    pub(crate) fn node_type(&self) -> NodeType {
+    pub fn node_type(&self) -> NodeType {
         match self {
             Object::Device(_) => NodeType::Device,
             Object::Block(_) => NodeType::Block,
@@ -494,7 +507,7 @@ impl Object {
     }
 
     /// Get the fieldset refs of the object. Only returns non-zero for registers and commands
-    pub(crate) fn fieldset_refs(&self) -> Vec<Spanned<IdentifierRef<Type>>> {
+    pub fn fieldset_refs(&self) -> Vec<Spanned<IdentifierRef<Type>>> {
         match self {
             Object::Device(_) => Vec::new(),
             Object::Block(_) => Vec::new(),
@@ -519,6 +532,10 @@ pub struct Block {
     pub address_offset: Spanned<i128>,
     pub repeat: Option<Repeat>,
     pub objects: Vec<Object>,
+    pub default_access: Option<Access>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -540,12 +557,15 @@ impl Block {
 pub struct Register {
     pub description: String,
     pub name: Spanned<Identifier<Operation>>,
-    pub access: Access,
+    pub access: Option<Access>,
     pub allow_address_overlap: bool,
     pub address: Spanned<i128>,
     pub reset_value: Option<Spanned<ResetValue>>,
     pub repeat: Option<Repeat>,
     pub field_set_ref: Spanned<IdentifierRef<Type>>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -557,7 +577,11 @@ pub struct FieldSet {
     pub size_bytes: Spanned<u32>,
     pub byte_order: Option<ByteOrder>,
     pub allow_bit_overlap: bool,
+    pub default_access: Option<Access>,
     pub fields: Vec<Field>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -572,11 +596,14 @@ impl FieldSet {
 pub struct Field {
     pub description: String,
     pub name: Spanned<Identifier<All>>,
-    pub access: Access,
+    pub access: Option<Access>,
     pub base_type: Spanned<BaseType>,
     pub field_conversion: Option<TypeConversion>,
     pub field_address: Spanned<AddressRange>,
     pub repeat: Option<Repeat>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -606,12 +633,15 @@ pub struct Enum {
     pub base_type: Spanned<BaseType>,
     pub size_bits: Option<u32>,
     pub generation_style: Option<EnumGenerationStyle>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
 
 impl Enum {
-    #[must_use]
+    #[cfg(test)]
     pub fn new(
         description: String,
         name: Spanned<Identifier<Type>>,
@@ -627,6 +657,8 @@ impl Enum {
             base_type,
             size_bits,
             generation_style: None,
+            short_properties_span: Span::empty(),
+            properties_span: Span::empty(),
             span,
         }
     }
@@ -648,6 +680,8 @@ impl Enum {
             base_type,
             size_bits,
             generation_style: Some(generation_style),
+            short_properties_span: Span::empty(),
+            properties_span: Span::empty(),
             span,
         }
     }
@@ -770,6 +804,8 @@ pub struct Command {
     pub field_set_ref_in: Option<Spanned<IdentifierRef<Type>>>,
     pub field_set_ref_out: Option<Spanned<IdentifierRef<Type>>>,
 
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -778,8 +814,11 @@ pub struct Command {
 pub struct Buffer {
     pub description: String,
     pub name: Spanned<Identifier<Operation>>,
-    pub access: Access,
+    pub access: Option<Access>,
     pub address: Spanned<i128>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -794,6 +833,9 @@ pub struct Extern {
     pub supports_infallible: bool,
     /// The user-specified size of the max value of the base type that should be expected
     pub size_bits: Option<Spanned<u64>>,
+
+    pub short_properties_span: Span,
+    pub properties_span: Span,
     /// Span of the whole object
     pub span: Span,
 }
@@ -1021,9 +1063,6 @@ mod tests {
                 Object::Device(Device {
                     description: String::new(),
                     name: Identifier::try_parse("a").unwrap().with_dummy_span(),
-                    device_config: DeviceConfig {
-                        ..Default::default()
-                    },
                     objects: vec![
                         Object::Extern(Extern {
                             name: Identifier::try_parse("b").unwrap().with_dummy_span(),
@@ -1034,15 +1073,14 @@ mod tests {
                             ..Default::default()
                         }),
                     ],
-                    span: Span::default(),
+                    ..Default::default()
                 }),
                 Object::Extern(Extern {
                     name: Identifier::try_parse("d").unwrap().with_dummy_span(),
                     ..Default::default()
                 }),
             ],
-            config: Default::default(),
-            span: Default::default(),
+            ..Default::default()
         };
 
         let names: Vec<_> = manifest

--- a/compiler/dd-mir/src/passes/access_set.rs
+++ b/compiler/dd-mir/src/passes/access_set.rs
@@ -50,7 +50,7 @@ fn set_access(
                         diagnostics.add(UnspecifiedAccess {
                             object_name: field.name.span,
                             short_property: true,
-                            properties_span: field.short_properties_span,
+                            properties_span: Some(field.short_properties_span),
                         });
                     }
                 }

--- a/compiler/dd-mir/src/passes/access_set.rs
+++ b/compiler/dd-mir/src/passes/access_set.rs
@@ -1,0 +1,91 @@
+use std::collections::HashSet;
+
+use device_driver_common::specifiers::Access;
+use device_driver_diagnostics::{Diagnostics, DynError, errors::UnspecifiedAccess};
+
+use crate::{
+    model::{Manifest, Object, UniqueId},
+    passes::Pass,
+};
+
+use super::Assumption;
+
+pub struct AccessSet;
+
+impl Pass for AccessSet {
+    const ASSUMPTIONS_MADE: &[Assumption] = &[];
+    const ASSUMPTIONS_RELEASED: &[Assumption] = &[Assumption::AccessSet];
+
+    fn run_pass(
+        manifest: &mut Manifest,
+        diagnostics: &mut Diagnostics,
+    ) -> Result<HashSet<UniqueId>, DynError> {
+        set_access(manifest.default_access, &mut manifest.objects, diagnostics);
+        Ok(Default::default())
+    }
+}
+
+fn set_access(
+    default_access: Option<Access>,
+    objects: &mut [Object],
+    diagnostics: &mut Diagnostics,
+) {
+    for object in objects {
+        match object {
+            Object::Device(device) => {
+                let default_access = device.default_access.or(default_access);
+                set_access(default_access, &mut device.objects, diagnostics);
+            }
+            Object::Block(block) => {
+                let default_access = block.default_access.or(default_access);
+                set_access(default_access, &mut block.objects, diagnostics);
+            }
+            Object::FieldSet(field_set) => {
+                let default_access = field_set.default_access.or(default_access);
+                for field in field_set.fields.iter_mut() {
+                    field.access = field.access.or(default_access);
+
+                    if field.access.is_none() {
+                        field.access = Some(Access::RW);
+                        diagnostics.add(UnspecifiedAccess {
+                            object_name: field.name.span,
+                            short_property: true,
+                            properties_span: field.short_properties_span,
+                        });
+                    }
+                }
+            }
+            Object::Register(register) => {
+                register.access = register.access.or(default_access);
+
+                if register.access.is_none() {
+                    register.access = Some(Access::RW);
+                    diagnostics.add(UnspecifiedAccess {
+                        object_name: register.name.span,
+                        short_property: false,
+                        properties_span: register.properties_span,
+                    });
+                }
+            }
+            Object::Buffer(buffer) => {
+                buffer.access = buffer.access.or(default_access);
+
+                if buffer.access.is_none() {
+                    buffer.access = Some(Access::RW);
+                    diagnostics.add(UnspecifiedAccess {
+                        object_name: buffer.name.span,
+                        short_property: false,
+                        properties_span: buffer.properties_span,
+                    });
+                }
+            }
+
+            Object::Field(_) => {
+                // Intentionally left empty as fields are done inline in the fieldset case
+            }
+            Object::Command(_) | Object::Enum(_) | Object::Extern(_) => {
+                // Intentionally left empty as they don't have children we care about and they don't carry an access specifier themselves
+            }
+        }
+    }
+}

--- a/compiler/dd-mir/src/passes/address_types_big_enough.rs
+++ b/compiler/dd-mir/src/passes/address_types_big_enough.rs
@@ -99,11 +99,7 @@ fn check_device(
 
 #[cfg(test)]
 mod tests {
-    use device_driver_common::{
-        identifier::Identifier,
-        span::{Span, SpanExt},
-        specifiers::Integer,
-    };
+    use device_driver_common::{identifier::Identifier, span::SpanExt, specifiers::Integer};
 
     use crate::model::{Command, Device, DeviceConfig, Register};
 
@@ -123,7 +119,7 @@ mod tests {
                 address: (-300).with_dummy_span(),
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -150,7 +146,7 @@ mod tests {
                 address: 128000.with_dummy_span(),
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 

--- a/compiler/dd-mir/src/passes/address_types_specified.rs
+++ b/compiler/dd-mir/src/passes/address_types_specified.rs
@@ -36,22 +36,17 @@ impl Pass for AddressTypesSpecified {
                         continue;
                     }
 
-                    let device_first_object =
+                    let device_properties_span =
                         search_object(manifest, &device.identifier().take_ref())
                             .ok_or_else(|| {
                                 DynError::new("config owner doesn't exist for register")
                             })?
-                            .child_objects()
-                            .first()
-                            .ok_or_else(|| {
-                                DynError::new("device that owns register doesn't have children")
-                            })?
-                            .span();
+                            .properties_span();
 
                     diagnostics.add(AddressTypeUndefined {
                         object_name: object.name_span(),
                         device: device.span(),
-                        device_config_area: device_first_object,
+                        properties_span: device_properties_span,
                         object_type: "register",
                     });
                     register_removals.insert(device.clone());
@@ -67,20 +62,15 @@ impl Pass for AddressTypesSpecified {
                         continue;
                     }
 
-                    let device_first_object =
+                    let device_properties_span =
                         search_object(manifest, &device.identifier().take_ref())
                             .ok_or_else(|| DynError::new("config owner doesn't exist for command"))?
-                            .child_objects()
-                            .first()
-                            .ok_or_else(|| {
-                                DynError::new("device that owns command doesn't have children")
-                            })?
-                            .span();
+                            .properties_span();
 
                     diagnostics.add(AddressTypeUndefined {
                         object_name: object.name_span(),
                         device: device.span(),
-                        device_config_area: device_first_object,
+                        properties_span: device_properties_span,
                         object_type: "command",
                     });
                     command_removals.insert(device.clone());
@@ -96,20 +86,15 @@ impl Pass for AddressTypesSpecified {
                         continue;
                     }
 
-                    let device_first_object =
+                    let device_properties_span =
                         search_object(manifest, &device.identifier().take_ref())
                             .ok_or_else(|| DynError::new("config owner doesn't exist for buffer"))?
-                            .child_objects()
-                            .first()
-                            .ok_or_else(|| {
-                                DynError::new("device that owns buffer doesn't have children")
-                            })?
-                            .span();
+                            .properties_span();
 
                     diagnostics.add(AddressTypeUndefined {
                         object_name: object.name_span(),
                         device: device.span(),
-                        device_config_area: device_first_object,
+                        properties_span: device_properties_span,
                         object_type: "buffer",
                     });
                     buffer_removals.insert(device.clone());

--- a/compiler/dd-mir/src/passes/bit_ranges_validated.rs
+++ b/compiler/dd-mir/src/passes/bit_ranges_validated.rs
@@ -174,7 +174,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 1.with_dummy_span(),
@@ -185,7 +184,7 @@ mod tests {
                 }],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -196,7 +195,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 1.with_dummy_span(),
@@ -207,7 +205,7 @@ mod tests {
                 }],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -218,7 +216,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 1.with_dummy_span(),
@@ -234,7 +231,7 @@ mod tests {
                 }],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -248,7 +245,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 2.with_dummy_span(),
@@ -268,7 +264,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -279,7 +275,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 2.with_dummy_span(),
@@ -300,7 +295,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -311,7 +306,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 2.with_dummy_span(),
@@ -331,7 +325,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -343,7 +337,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyReg").unwrap().with_dummy_span(),
                 size_bytes: 2.with_dummy_span(),
@@ -368,7 +361,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 

--- a/compiler/dd-mir/src/passes/byte_order_specified.rs
+++ b/compiler/dd-mir/src/passes/byte_order_specified.rs
@@ -28,6 +28,7 @@ impl Pass for ByteOrderSpecified {
                 if fs.size_bytes > 1 && fs.byte_order.is_none() {
                     diagnostics.add(UnspecifiedByteOrder {
                         fieldset_name: fs.name.span,
+                        properties_span: fs.properties_span,
                     });
                 }
 
@@ -42,11 +43,7 @@ impl Pass for ByteOrderSpecified {
 
 #[cfg(test)]
 mod tests {
-    use device_driver_common::{
-        identifier::Identifier,
-        span::{Span, SpanExt},
-        specifiers::ByteOrder,
-    };
+    use device_driver_common::{identifier::Identifier, span::SpanExt, specifiers::ByteOrder};
 
     use crate::model::{Device, DeviceConfig, FieldSet, Object};
 
@@ -57,7 +54,6 @@ mod tests {
         let mut input = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![
                 Object::FieldSet(FieldSet {
                     name: Identifier::try_parse("MyRegister")
@@ -75,7 +71,7 @@ mod tests {
                     ..Default::default()
                 }),
             ],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -89,7 +85,6 @@ mod tests {
         let mut input = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::FieldSet(FieldSet {
                 name: Identifier::try_parse("MyRegister")
                     .unwrap()
@@ -97,7 +92,7 @@ mod tests {
                 size_bytes: 2.with_dummy_span(),
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -124,7 +119,7 @@ mod tests {
                 size_bytes: 2.with_dummy_span(),
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 

--- a/compiler/dd-mir/src/passes/enum_values_checked.rs
+++ b/compiler/dd-mir/src/passes/enum_values_checked.rs
@@ -305,7 +305,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -335,14 +334,13 @@ mod tests {
                 Some(2),
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
         let end_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new_with_style(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -373,7 +371,7 @@ mod tests {
                 EnumGenerationStyle::InfallibleWithinRange,
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -389,7 +387,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -409,14 +406,13 @@ mod tests {
                 Some(8),
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
         let end_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new_with_style(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -437,7 +433,7 @@ mod tests {
                 EnumGenerationStyle::Fallback,
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -453,7 +449,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -466,14 +461,13 @@ mod tests {
                 Some(16),
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
         let end_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new_with_style(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -487,7 +481,7 @@ mod tests {
                 EnumGenerationStyle::Fallible,
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -503,7 +497,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -528,7 +521,7 @@ mod tests {
                 Some(1),
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -546,7 +539,6 @@ mod tests {
         let mut start_mir = Device {
             description: String::new(),
             name: Identifier::try_parse("Device").unwrap().with_dummy_span(),
-            device_config: Default::default(),
             objects: vec![Object::Enum(Enum::new(
                 Default::default(),
                 Identifier::try_parse("MyEnum").unwrap().with_dummy_span(),
@@ -566,7 +558,7 @@ mod tests {
                 Some(8),
                 Span::default(),
             ))],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 

--- a/compiler/dd-mir/src/passes/mod.rs
+++ b/compiler/dd-mir/src/passes/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     MirOptions, PassTiming,
     model::{Manifest, UniqueId},
     passes::{
-        address_types_big_enough::AddressTypesBigEnough,
+        access_set::AccessSet, address_types_big_enough::AddressTypesBigEnough,
         address_types_specified::AddressTypesSpecified,
         addresses_non_overlapping::AddressesNonOverlapping,
         base_types_specified::BaseTypesSpecified, bit_ranges_validated::BitRangesValidated,
@@ -21,6 +21,7 @@ use crate::{
 use device_driver_common::instant::Instant;
 use device_driver_diagnostics::{Diagnostics, DynError, ResultExt};
 
+mod access_set;
 mod address_types_big_enough;
 mod address_types_specified;
 mod addresses_non_overlapping;
@@ -42,7 +43,7 @@ mod reserved_names_checked;
 mod reset_values_converted;
 
 // TODO: Make const when possible in a future Rust version
-fn get_default_passes() -> [PassInfo; 19] {
+fn get_default_passes() -> [PassInfo; 20] {
     [
         PassInfo::get::<DeviceConfigsOwned>(),
         PassInfo::get::<EnumValuesChecked>(),
@@ -50,6 +51,7 @@ fn get_default_passes() -> [PassInfo; 19] {
         PassInfo::get::<BaseTypesSpecified>(),
         PassInfo::get::<DeviceNameIsPascal>(),
         PassInfo::get::<NamesChecked>(),
+        PassInfo::get::<AccessSet>(),
         PassInfo::get::<NamesUnique>(),
         PassInfo::get::<FieldsetRefsValid>(),
         PassInfo::get::<RepeatZeroStrideRejected>(),
@@ -125,6 +127,7 @@ pub(crate) enum Assumption {
     NamesValid,
     EnumsNotEmpty,
     RepeatMathChecked,
+    AccessSet,
 
     _End, // Keep as the last element
 }
@@ -144,6 +147,7 @@ impl Assumption {
         Assumption::NamesValid,
         Assumption::EnumsNotEmpty,
         Assumption::RepeatMathChecked,
+        Assumption::AccessSet,
     ];
 
     const _ALL_ASSUMPTIONS_PRESENT_CHECK: () =

--- a/compiler/dd-mir/src/passes/names_unique.rs
+++ b/compiler/dd-mir/src/passes/names_unique.rs
@@ -132,10 +132,7 @@ impl<T: Eq> EqSet<T> {
 #[cfg(test)]
 mod tests {
     use convert_case::Boundary;
-    use device_driver_common::{
-        identifier::Identifier,
-        span::{Span, SpanExt},
-    };
+    use device_driver_common::{identifier::Identifier, span::SpanExt};
 
     use crate::model::{Buffer, Device, DeviceConfig, Enum, EnumVariant, Field, FieldSet, Object};
 
@@ -162,7 +159,7 @@ mod tests {
                     ..Default::default()
                 }),
             ],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -196,7 +193,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 
@@ -230,7 +227,7 @@ mod tests {
                 ],
                 ..Default::default()
             })],
-            span: Span::default(),
+            ..Default::default()
         }
         .into();
 

--- a/compiler/dd-mir/src/passes/reserved_names_checked.rs
+++ b/compiler/dd-mir/src/passes/reserved_names_checked.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use convert_case::Case;
 use device_driver_common::{identifier::RuntimeType, specifiers::Access};
 use device_driver_diagnostics::{
-    Diagnostics, DynError,
+    Diagnostics, DynError, ResultExt,
     errors::{FieldSetterNameCollision, ReservedOperationNameUsed},
 };
 
@@ -17,7 +17,7 @@ use super::Assumption;
 pub struct ReservedNamesChecked;
 
 impl Pass for ReservedNamesChecked {
-    const ASSUMPTIONS_MADE: &[Assumption] = &[Assumption::NamesValid];
+    const ASSUMPTIONS_MADE: &[Assumption] = &[Assumption::NamesValid, Assumption::AccessSet];
     const ASSUMPTIONS_RELEASED: &[Assumption] = &[];
 
     fn run_pass(
@@ -36,7 +36,9 @@ impl Pass for ReservedNamesChecked {
                     check_block_reserved_names(block.iter_objects(), diagnostics)
                 }
                 Object::FieldSet(field_set) => {
-                    check_field_names(field_set, diagnostics);
+                    check_field_names(field_set, diagnostics).with_message(|| {
+                        format!("checking field names of {}", field_set.name.original())
+                    })?;
                     HashSet::new()
                 }
                 _ => HashSet::new(),
@@ -77,7 +79,10 @@ fn check_block_reserved_names<'a>(
     removals
 }
 
-fn check_field_names(field_set: &mut FieldSet, diagnostics: &mut Diagnostics) {
+fn check_field_names(
+    field_set: &mut FieldSet,
+    diagnostics: &mut Diagnostics,
+) -> Result<(), DynError> {
     let field_names: HashMap<_, _> = field_set
         .fields
         .iter()
@@ -85,7 +90,11 @@ fn check_field_names(field_set: &mut FieldSet, diagnostics: &mut Diagnostics) {
         .collect();
 
     for field in &mut field_set.fields {
-        if !field.access.is_writable() {
+        if !field
+            .access
+            .ok_or_else(|| DynError::new("access is not set"))?
+            .is_writable()
+        {
             continue;
         }
 
@@ -96,7 +105,7 @@ fn check_field_names(field_set: &mut FieldSet, diagnostics: &mut Diagnostics) {
         };
 
         // The setter collides with another field. To fix it for further compilation, we set it to read only so the setter is not generated
-        field.access = Access::RO;
+        field.access = Some(Access::RO);
 
         diagnostics.add(FieldSetterNameCollision {
             field: field.name.span,
@@ -104,4 +113,6 @@ fn check_field_names(field_set: &mut FieldSet, diagnostics: &mut Diagnostics) {
             collision_field,
         });
     }
+
+    Ok(())
 }

--- a/device-driver/tests/basic-block.rs
+++ b/device-driver/tests/basic-block.rs
@@ -50,6 +50,7 @@ device_driver::compile!(
         device MyTestDevice {
             byte-order: LE,
             register-address-type: u8,
+            default-access: RW,
 
             /// Block description
             block Bar[2 stride 20] {

--- a/device-driver/tests/basic-command.rs
+++ b/device-driver/tests/basic-command.rs
@@ -32,6 +32,8 @@ device_driver::compile!(
         device MyTestDevice {
             byte-order: LE,
             command-address-type: u8,
+            default-access: RW,
+            
             /// A simple command
             command Simple {
                 address: 0

--- a/device-driver/tests/basic-register-async.rs
+++ b/device-driver/tests/basic-register-async.rs
@@ -31,6 +31,7 @@ device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
             register-address-type: u8,
+            default-access: RW,
 
             register Foo {
                 address: 0,

--- a/device-driver/tests/basic-register.ddsl
+++ b/device-driver/tests/basic-register.ddsl
@@ -1,6 +1,7 @@
 device MyTestDevice {
     byte-order: LE,
     register-address-type: u8,
+    default-access: RW,
 
     /// This is the Foo register
     register Foo {

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -54,6 +54,7 @@ device_driver::compile!(
         device MyTestDevice {
             byte-order: LE,
             register-address-type: u8,
+            default-access: RW,
 
             /// This is the Foo register
             register Foo {

--- a/device-driver/tests/bit-ops.rs
+++ b/device-driver/tests/bit-ops.rs
@@ -5,6 +5,7 @@ device_driver::compile!(
         device MyTestDevice {
             byte-order: LE,
             register-address-type: u8,
+            default-access: RW,
 
             register Foo {
                 address: 0,

--- a/device-driver/tests/bulk-register.rs
+++ b/device-driver/tests/bulk-register.rs
@@ -51,6 +51,7 @@ device_driver::compile!(
             byte-order: LE,
             register-address-type: u8,
             register-address-mode: mapped,
+            default-access: RW,
 
             register Foo {
                 address: 0,

--- a/device-driver/tests/docs-everywhere.rs
+++ b/device-driver/tests/docs-everywhere.rs
@@ -8,6 +8,8 @@ device_driver::compile!(
             register-address-type: u8,
             command-address-type: u8,
             buffer-address-type: u8,
+            default-access: RW,
+            
             /// X
             register Foo {
                 address: 0,

--- a/device-driver/tests/endianness-respected.rs
+++ b/device-driver/tests/endianness-respected.rs
@@ -34,6 +34,7 @@ device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
             register-address-type: u8,
+            default-access: RW,
 
             register FooLE {
                 address-overlap: allow,

--- a/device-driver/tests/large-register.rs
+++ b/device-driver/tests/large-register.rs
@@ -30,6 +30,7 @@ device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
             register-address-type: u8,
+            default-access: RW,
 
             register FooLe {
                 address: 0,

--- a/device-driver/tests/register-access.rs
+++ b/device-driver/tests/register-access.rs
@@ -4,6 +4,7 @@ device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
             register-address-type: u8,
+            default-access: RW,
 
             register Foo {
                 address: 0,

--- a/device-driver/tests/type-conversions.rs
+++ b/device-driver/tests/type-conversions.rs
@@ -50,6 +50,8 @@ device_driver::compile!(
         device MyTestDevice {
             byte-order: LE,
             register-address-type: u8,
+            default-access: RW,
+
             register Foo {
                 address: 0,
                 fields: fieldset FooFields {

--- a/tests/ui/cases/address_types/input.ddsl
+++ b/tests/ui/cases/address_types/input.ddsl
@@ -3,6 +3,7 @@ device Device {
     register-address-type: u16,
     command-address-type: i32,
     buffer-address-type: i8,
+    default-access: RW,
 
     register Foo {
         address: 0,

--- a/tests/ui/cases/basic_command/input.ddsl
+++ b/tests/ui/cases/basic_command/input.ddsl
@@ -1,6 +1,7 @@
 device Device {
     byte-order: LE,
     command-address-type: u8,
+    default-access: RW,
 
     command Foo {
         address: 0,

--- a/tests/ui/cases/basic_register/input.ddsl
+++ b/tests/ui/cases/basic_register/input.ddsl
@@ -2,6 +2,7 @@
 device Device {
     byte-order: LE,
     register-address-type: u8,
+    default-access: RW,
 
     register Foo {
         address: 0,

--- a/tests/ui/cases/compile_time_explosion/input.ddsl
+++ b/tests/ui/cases/compile_time_explosion/input.ddsl
@@ -1,6 +1,7 @@
 device Device {
     byte-order: LE,
     register-address-type: u32,
+    default-access: RW,
 
     fieldset Foo {
         size-bytes: 0

--- a/tests/ui/cases/default_access/default_access.rs
+++ b/tests/ui/cases/default_access/default_access.rs
@@ -1,0 +1,212 @@
+#!/usr/bin/env cargo
+---
+[package]
+edition = "2024"
+[dependencies]
+device-driver = { path="../../../../device-driver", default-features=false }
+---
+#![deny(warnings)]
+#![allow(unexpected_cfgs)]
+fn main() {}
+
+// This code was generated using device-driver `xx.xx.xx` (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx),
+// a tool distributed under MIT OR Apache-2.0 by Dion Dokter <dev@diondokter.nl>
+// This version was built for xxxx-xxxx-xxxx using rustc 1.xx.x (xxxxxxxxx xxxx-xx-xx)
+// 
+// For more information about device-driver, visit the website: https://device-driver.com
+
+/// Root block of the Y driver
+#[derive(Debug)]
+pub struct Y<I> {
+    interface: I,
+    #[doc(hidden)]
+    #[allow(unused)]
+    base_address: u8,
+}
+impl<I> Y<I> {
+    /// Create a new instance of the device
+    pub const fn new(interface: I) -> Self {
+        Self { interface, base_address: 0 }
+    }
+    /// Drop the driver instance and reclaim the interface
+    pub fn free(self) -> I {
+        self.interface
+    }
+    /// Register operation:
+    /// - Address: `0`
+    /// - Reset value: `0`
+    #[doc(alias = "Z")]
+    pub fn z(
+        &mut self,
+    ) -> ::device_driver::RegisterOperation<'_, Self, A, u8, ::device_driver::RO, ()>
+    where
+        I: ::device_driver::RegisterInterfaceBase<AddressType = u8>,
+    {
+        let address = self.base_address + 0;
+        ::device_driver::RegisterOperation::new(self, address as u8, A::default)
+    }
+    /// Block operation:
+    /// - Address: `0`
+    #[doc(alias = "B")]
+    pub fn b(&mut self) -> B<'_, I> {
+        let address = self.base_address + 0;
+        B::<'_, I>::new(::device_driver::Block::interface(self), address)
+    }
+}
+impl<I> ::device_driver::Block for Y<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    type RegisterAddressMode = ();
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
+#[derive(Debug)]
+pub struct B<'i, I> {
+    #[doc(hidden)]
+    interface: &'i mut I,
+    #[doc(hidden)]
+    #[allow(unused)]
+    base_address: u8,
+}
+impl<'i, I> B<'i, I> {
+    /// Create a new instance of the block based on device interface
+    #[doc(hidden)]
+    fn new(interface: &'i mut I, base_address: u8) -> Self {
+        Self {
+            interface,
+            base_address: base_address,
+        }
+    }
+    /// Register operation:
+    /// - Address: `1`
+    /// - Reset value: `0`
+    #[doc(alias = "C")]
+    pub fn c(
+        &mut self,
+    ) -> ::device_driver::RegisterOperation<'_, Self, A, u8, ::device_driver::WO, ()>
+    where
+        I: ::device_driver::RegisterInterfaceBase<AddressType = u8>,
+    {
+        let address = self.base_address + 1;
+        ::device_driver::RegisterOperation::new(self, address as u8, A::default)
+    }
+}
+impl<'i, I> ::device_driver::Block for B<'i, I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    type RegisterAddressMode = ();
+    fn interface(&mut self) -> &mut Self::Interface {
+        self.interface
+    }
+}
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct A {
+    #[doc(hidden)]
+    /// The internal bits
+    bits: [u8; 1],
+}
+unsafe impl ::device_driver::Fieldset for A {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
+    const ZERO: Self = Self { bits: [0; 1] };
+}
+impl A {
+    /// `bit 0` - Set the `a` field.
+    ///
+    pub fn set_a(&mut self, value: bool) {
+        let start = 0;
+        let end = 0;
+        let raw = value as _;
+        unsafe {
+            ::device_driver::ops::store::<
+                u8,
+                ::device_driver::ops::LE,
+            >(raw, start, end, &mut self.bits)
+        };
+    }
+}
+impl Default for A {
+    fn default() -> Self {
+        <Self as ::device_driver::Fieldset>::ZERO
+    }
+}
+impl From<[u8; 1]> for A {
+    fn from(bits: [u8; 1]) -> Self {
+        Self { bits }
+    }
+}
+impl From<A> for [u8; 1] {
+    fn from(val: A) -> Self {
+        val.bits
+    }
+}
+impl core::fmt::Debug for A {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        let mut d = f.debug_struct("A");
+        d.finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for A {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "A {{ ");
+        defmt::write!(f, "}}");
+    }
+}
+impl core::ops::BitAnd for A {
+    type Output = Self;
+    fn bitand(mut self, rhs: Self) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+impl core::ops::BitAndAssign for A {
+    fn bitand_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l &= *r;
+        }
+    }
+}
+impl core::ops::BitOr for A {
+    type Output = Self;
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+impl core::ops::BitOrAssign for A {
+    fn bitor_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l |= *r;
+        }
+    }
+}
+impl core::ops::BitXor for A {
+    type Output = Self;
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+impl core::ops::BitXorAssign for A {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l ^= *r;
+        }
+    }
+}
+impl core::ops::Not for A {
+    type Output = Self;
+    fn not(mut self) -> Self::Output {
+        for val in self.bits.iter_mut() {
+            *val = !*val;
+        }
+        self
+    }
+}

--- a/tests/ui/cases/default_access/default_access.rs
+++ b/tests/ui/cases/default_access/default_access.rs
@@ -104,6 +104,59 @@ impl<'i, I> ::device_driver::Block for B<'i, I> {
         self.interface
     }
 }
+/// Root block of the D driver
+#[derive(Debug)]
+pub struct D<I> {
+    interface: I,
+    #[doc(hidden)]
+    #[allow(unused)]
+    base_address: u8,
+}
+impl<I> D<I> {
+    /// Create a new instance of the device
+    pub const fn new(interface: I) -> Self {
+        Self { interface, base_address: 0 }
+    }
+    /// Drop the driver instance and reclaim the interface
+    pub fn free(self) -> I {
+        self.interface
+    }
+    /// Register operation:
+    /// - Address: `0`
+    /// - Reset value: `0`
+    #[doc(alias = "E")]
+    pub fn e(
+        &mut self,
+    ) -> ::device_driver::RegisterOperation<'_, Self, F, u8, ::device_driver::RW, ()>
+    where
+        I: ::device_driver::RegisterInterfaceBase<AddressType = u8>,
+    {
+        let address = self.base_address + 0;
+        ::device_driver::RegisterOperation::new(self, address as u8, F::default)
+    }
+    /// Buffer operation:
+    /// - Address: `0`
+    #[doc(alias = "G")]
+    pub fn g(
+        &mut self,
+    ) -> ::device_driver::BufferOperation<'_, Self, u8, ::device_driver::RW>
+    where
+        I: ::device_driver::BufferInterfaceBase<AddressType = u8>,
+    {
+        let address = self.base_address + 0;
+        ::device_driver::BufferOperation::new(self, address as u8)
+    }
+}
+impl<I> ::device_driver::Block for D<I> {
+    type Interface = I;
+    type RegisterAddressType = u8;
+    type CommandAddressType = u8;
+    type BufferAddressType = u8;
+    type RegisterAddressMode = ();
+    fn interface(&mut self) -> &mut Self::Interface {
+        &mut self.interface
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct A {
@@ -210,3 +263,126 @@ impl core::ops::Not for A {
         self
     }
 }
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct F {
+    #[doc(hidden)]
+    /// The internal bits
+    bits: [u8; 1],
+}
+unsafe impl ::device_driver::Fieldset for F {
+    const METADATA: ::device_driver::FieldsetMetadata = ::device_driver::FieldsetMetadata::new()
+        .with_byte_order(::device_driver::ByteOrder::LE);
+    const ZERO: Self = Self { bits: [0; 1] };
+}
+impl F {
+    /// `bit 0` - Read the `a` field.
+    ///
+    #[must_use]
+    pub fn a(&self) -> bool {
+        let start = 0;
+        let end = 0;
+        let raw = unsafe {
+            ::device_driver::ops::load::<
+                u8,
+                ::device_driver::ops::LE,
+            >(&self.bits, start, end)
+        };
+        raw > 0
+    }
+    /// `bit 0` - Set the `a` field.
+    ///
+    pub fn set_a(&mut self, value: bool) {
+        let start = 0;
+        let end = 0;
+        let raw = value as _;
+        unsafe {
+            ::device_driver::ops::store::<
+                u8,
+                ::device_driver::ops::LE,
+            >(raw, start, end, &mut self.bits)
+        };
+    }
+}
+impl Default for F {
+    fn default() -> Self {
+        <Self as ::device_driver::Fieldset>::ZERO
+    }
+}
+impl From<[u8; 1]> for F {
+    fn from(bits: [u8; 1]) -> Self {
+        Self { bits }
+    }
+}
+impl From<F> for [u8; 1] {
+    fn from(val: F) -> Self {
+        val.bits
+    }
+}
+impl core::fmt::Debug for F {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        let mut d = f.debug_struct("F");
+        d.field("a", &self.a());
+        d.finish()
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for F {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "F {{ ");
+        defmt::write!(f, "a: {=bool}, ", & self.a());
+        defmt::write!(f, "}}");
+    }
+}
+impl core::ops::BitAnd for F {
+    type Output = Self;
+    fn bitand(mut self, rhs: Self) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+impl core::ops::BitAndAssign for F {
+    fn bitand_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l &= *r;
+        }
+    }
+}
+impl core::ops::BitOr for F {
+    type Output = Self;
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+impl core::ops::BitOrAssign for F {
+    fn bitor_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l |= *r;
+        }
+    }
+}
+impl core::ops::BitXor for F {
+    type Output = Self;
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+impl core::ops::BitXorAssign for F {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for (l, r) in self.bits.iter_mut().zip(&rhs.bits) {
+            *l ^= *r;
+        }
+    }
+}
+impl core::ops::Not for F {
+    type Output = Self;
+    fn not(mut self) -> Self::Output {
+        for val in self.bits.iter_mut() {
+            *val = !*val;
+        }
+        self
+    }
+}
+compile_error!("The device driver input has errors that need to be solved!");

--- a/tests/ui/cases/default_access/diagnostics.txt
+++ b/tests/ui/cases/default_access/diagnostics.txt
@@ -1,0 +1,33 @@
+error: unspecified access
+  --> input.ddsl:31:18
+   |
+LL |         register E {
+   |                  ^ object requires an access to be specified, but none is
+   |
+help: specify the access on the object or add a `default-access` to a parent object
+   |
+LL +             access: RW,
+   |
+
+error: unspecified access
+  --> input.ddsl:38:16
+   |
+LL |         buffer G {
+   |                ^ object requires an access to be specified, but none is
+   |
+help: specify the access on the object or add a `default-access` to a parent object
+   |
+LL +             access: RW,
+   |
+
+error: unspecified access
+  --> input.ddsl:35:23
+   |
+LL |                 field a 0,
+   |                       ^ object requires an access to be specified, but none is
+   |
+help: specify the access on the object or add a `default-access` to a parent object
+   |
+LL |                 field a 0 RW,
+   |                           ++
+

--- a/tests/ui/cases/default_access/input.ddsl
+++ b/tests/ui/cases/default_access/input.ddsl
@@ -1,0 +1,27 @@
+manifest X {
+    default-access: RW,
+
+    device Y {
+        register-address-type: u8,
+        default-access: RO,
+
+        register Z {
+            address: 0,
+            fields: fieldset A {
+                size-bytes: 1,
+                default-access: WO,
+                field a 0,
+            },
+        },
+
+        block B {
+            default-access: WO,
+            address-offset: 0,
+
+            register C {
+                address: 1,
+                fields: A,
+            },
+        }
+    },
+}

--- a/tests/ui/cases/default_access/input.ddsl
+++ b/tests/ui/cases/default_access/input.ddsl
@@ -1,6 +1,4 @@
 manifest X {
-    default-access: RW,
-
     device Y {
         register-address-type: u8,
         default-access: RO,
@@ -24,4 +22,21 @@ manifest X {
             },
         }
     },
+
+    // no default means it should error on all sites that need an access
+    device D {
+        register-address-type: u8,
+        buffer-address-type: u8,
+
+        register E {
+            address: 0,
+            fields: fieldset F {
+                size-bytes: 1,
+                field a 0,
+            },
+        },
+        buffer G {
+            address: 0,
+        }
+    }
 }

--- a/tests/ui/cases/default_access/stderr.rs.txt
+++ b/tests/ui/cases/default_access/stderr.rs.txt
@@ -1,0 +1,7 @@
+error: The device driver input has errors that need to be solved!
+   --> default_access.rs:388:1
+    |
+388 | compile_error!("The device driver input has errors that need to be solved!");
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: could not compile `default_access` (bin "default_access") due to 1 previous error

--- a/tests/ui/cases/description_string_escapes/input.ddsl
+++ b/tests/ui/cases/description_string_escapes/input.ddsl
@@ -1,6 +1,8 @@
 device Device {
     byte-order: LE,
     register-address-type: u8,
+    default-access: RW,
+
     /// \\\\\\/\/\/\////\/\/;{}'"`'
     register Foo {
         address: 0,

--- a/tests/ui/cases/fieldset_access/input.ddsl
+++ b/tests/ui/cases/fieldset_access/input.ddsl
@@ -1,6 +1,8 @@
 device Device {
     byte-order: LE,
     register-address-type: u8,
+    default-access: RW,
+    
     register foo_ro {
         access: RO,
         address: 0,

--- a/tests/ui/cases/overlapping_names/diagnostics.txt
+++ b/tests/ui/cases/overlapping_names/diagnostics.txt
@@ -1,5 +1,5 @@
 error: duplicate name found
-  --> input.ddsl:22:12
+  --> input.ddsl:23:12
    |
 LL |     device Foo {
    |            --- the original: "Foo", after word split: "foo"
@@ -14,7 +14,7 @@ info: names may not collide within their namespace. There are 4 namespaces:
       - Enum variants: unique within an enum
 
 error: duplicate name found
-  --> input.ddsl:23:18
+  --> input.ddsl:24:18
    |
 LL |         register Bar {
    |                  --- the original: "Bar", after word split: "bar"
@@ -29,7 +29,7 @@ info: names may not collide within their namespace. There are 4 namespaces:
       - Enum variants: unique within an enum
 
 error: duplicate name found
-  --> input.ddsl:28:50
+  --> input.ddsl:29:50
    |
 LL |                 field quux 7:0 -> u8 as try enum _ { // Enum same name as field
    |                                                  - the original: "quux", after word split: "quux"
@@ -44,7 +44,7 @@ info: names may not collide within their namespace. There are 4 namespaces:
       - Enum variants: unique within an enum
 
 error: duplicate name found
-  --> input.ddsl:25:30
+  --> input.ddsl:26:30
    |
 LL |             fields: fieldset _ { // Fieldset same name as register
    |                              - the original: "Bar", after word split: "bar"
@@ -59,7 +59,7 @@ info: names may not collide within their namespace. There are 4 namespaces:
       - Enum variants: unique within an enum
 
 error: duplicate name found
-  --> input.ddsl:41:16
+  --> input.ddsl:42:16
    |
 LL |         block Wheee { // Should overlap with both operations and types
    |               ----- the original: "Wheee", after word split: "wheee"
@@ -74,7 +74,7 @@ info: names may not collide within their namespace. There are 4 namespaces:
       - Enum variants: unique within an enum
 
 error: duplicate name found
-  --> input.ddsl:47:14
+  --> input.ddsl:48:14
    |
 LL |         block Wheee2 { // Should overlap with both operations and types
    |               ------ the original: "Wheee2", after word split: "wheee·2"

--- a/tests/ui/cases/overlapping_names/input.ddsl
+++ b/tests/ui/cases/overlapping_names/input.ddsl
@@ -1,6 +1,7 @@
 manifest Foo {
     register-address-type: u8,
     buffer-address-type: u8,
+    default-access: RW,
 
     // These should be all fine
     device Foo {

--- a/tests/ui/cases/reserved_names/diagnostics.txt
+++ b/tests/ui/cases/reserved_names/diagnostics.txt
@@ -1,5 +1,5 @@
 error: reserved operation name used
-  --> input.ddsl:4:12
+  --> input.ddsl:5:12
    |
 LL |     buffer New {
    |            ^^^ `new` is a reserved name for operations. Change it to something else
@@ -7,7 +7,7 @@ LL |     buffer New {
 info: reserved names are: `new`, `init`, `deinit`, `free`
 
 error: reserved operation name used
-  --> input.ddsl:7:12
+  --> input.ddsl:8:12
    |
 LL |     buffer Init {
    |            ^^^^ `init` is a reserved name for operations. Change it to something else
@@ -15,7 +15,7 @@ LL |     buffer Init {
 info: reserved names are: `new`, `init`, `deinit`, `free`
 
 error: reserved operation name used
-  --> input.ddsl:10:12
+  --> input.ddsl:11:12
    |
 LL |     buffer Deinit {
    |            ^^^^^^ `deinit` is a reserved name for operations. Change it to something else
@@ -23,7 +23,7 @@ LL |     buffer Deinit {
 info: reserved names are: `new`, `init`, `deinit`, `free`
 
 error: reserved operation name used
-  --> input.ddsl:13:12
+  --> input.ddsl:14:12
    |
 LL |     buffer Free {
    |            ^^^^ `free` is a reserved name for operations. Change it to something else
@@ -31,7 +31,7 @@ LL |     buffer Free {
 info: reserved names are: `new`, `init`, `deinit`, `free`
 
 error: field setter name collision
-  --> input.ddsl:19:15
+  --> input.ddsl:20:15
    |
 LL |         field my_field 0,
    |               ^^^^^^^^ this field is writable and generates a setter with a name that collides with another field: `set·my·field`

--- a/tests/ui/cases/reserved_names/input.ddsl
+++ b/tests/ui/cases/reserved_names/input.ddsl
@@ -1,5 +1,6 @@
 device Foo {
     buffer-address-type: u16,
+    default-access: RW,
 
     buffer New {
         address: 0,


### PR DESCRIPTION
Access specifiers are mandatory now, unless a `default-access` value is set.
Also improved some span information and error messages.