### PR TITLE
Fix default properties

### DIFF
--- a/book/src/gen-docs/mir-shapes/device.md
+++ b/book/src/gen-docs/mir-shapes/device.md
@@ -3,7 +3,7 @@
 ```ddsl
 /// doc comment line
 device Example {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: i32,
     command-address-type: i32,
     buffer-address-type: i32,
@@ -33,11 +33,11 @@ device Example {
 | Supports subnodes | `yes`, see below |
 ## Long properties
 These properties are specified in the node body.
-### byte-order
+### default-byte-order
 Sets the default byte order used by fieldsets in this device. This can be overridden per fieldset.
 ```ddsl
 // byte order
-byte-order: LE
+default-byte-order: LE
 ```
 #### Info
 - required: `no`

--- a/book/src/gen-docs/mir-shapes/manifest.md
+++ b/book/src/gen-docs/mir-shapes/manifest.md
@@ -3,7 +3,7 @@
 ```ddsl
 /// doc comment line
 manifest Example {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: i32,
     command-address-type: i32,
     buffer-address-type: i32,
@@ -30,11 +30,11 @@ manifest Example {
 | Supports subnodes | `yes`, see below |
 ## Long properties
 These properties are specified in the node body.
-### byte-order
+### default-byte-order
 Sets the global default byte order used by fieldsets. This can be overridden per device and fieldset.
 ```ddsl
 // byte order
-byte-order: LE
+default-byte-order: LE
 ```
 #### Info
 - required: `no`

--- a/compiler/dd-converter/src/dd_v1.rs
+++ b/compiler/dd-converter/src/dd_v1.rs
@@ -51,7 +51,7 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
                 .default_byte_order
                 .map(|val| Property {
                     doc_comments: Vec::new(),
-                    name: Ident::new_no_span("byte-order"),
+                    name: Ident::new_no_span("default-byte-order"),
                     expression: Expression::ByteOrder(convert_byte_order(val)).with_dummy_span(),
                 }),
             device_mir
@@ -91,6 +91,11 @@ pub fn convert(source: &str, sub_format: DeviceDriverV1Format) -> Result<String,
                         .leak(),
                 )
                 .with_dummy_span(),
+            }),
+            Some(Property {
+                doc_comments: Vec::new(),
+                name: Ident::new_no_span("default-access"),
+                expression: Expression::Access(Access::RW).with_dummy_span(),
             }),
         ]
         .into_iter()

--- a/compiler/dd-diagnostics/src/errors.rs
+++ b/compiler/dd-diagnostics/src/errors.rs
@@ -1773,27 +1773,22 @@ impl Diagnostic for MissingRequiredProperty {
                         .label(label),
                 ),
             )
-            .elements(
-                self.example_values
-                    .iter()
-                    .map(|example_value| {
-                        self.properties_span.map(|properties_span| {
-                            Snippet::source(source).path(path).patch(Patch::new(
-                                if self.short {
-                                    properties_span.end..properties_span.end
-                                } else {
-                                    properties_span.start..properties_span.start
-                                },
-                                if self.short {
-                                    format!(" {example_value}")
-                                } else {
-                                    format!("{}: {example_value},\n", self.property_name)
-                                },
-                            ))
-                        })
-                    })
-                    .flatten(),
-            )]
+            .elements(self.example_values.iter().flat_map(|example_value| {
+                self.properties_span.map(|properties_span| {
+                    Snippet::source(source).path(path).patch(Patch::new(
+                        if self.short {
+                            properties_span.end..properties_span.end
+                        } else {
+                            properties_span.start..properties_span.start
+                        },
+                        if self.short {
+                            format!(" {example_value}")
+                        } else {
+                            format!("{}: {example_value},\n", self.property_name)
+                        },
+                    ))
+                })
+            }))]
         .to_vec()
     }
 }

--- a/compiler/dd-diagnostics/src/errors.rs
+++ b/compiler/dd-diagnostics/src/errors.rs
@@ -1773,24 +1773,27 @@ impl Diagnostic for MissingRequiredProperty {
                         .label(label),
                 ),
             )
-            .elements(self.properties_span.map(|properties_span| {
-                Snippet::source(source)
-                    .path(path)
-                    .patches(self.example_values.iter().map(|example_value| {
-                        Patch::new(
-                            if self.short {
-                                properties_span.end..properties_span.end
-                            } else {
-                                properties_span.start..properties_span.start
-                            },
-                            if self.short {
-                                format!(" {example_value}")
-                            } else {
-                                format!("{}: {example_value},\n", self.property_name)
-                            },
-                        )
-                    }))
-            }))]
+            .elements(
+                self.example_values
+                    .iter()
+                    .map(|example_value| {
+                        self.properties_span.map(|properties_span| {
+                            Snippet::source(source).path(path).patch(Patch::new(
+                                if self.short {
+                                    properties_span.end..properties_span.end
+                                } else {
+                                    properties_span.start..properties_span.start
+                                },
+                                if self.short {
+                                    format!(" {example_value}")
+                                } else {
+                                    format!("{}: {example_value},\n", self.property_name)
+                                },
+                            ))
+                        })
+                    })
+                    .flatten(),
+            )]
         .to_vec()
     }
 }

--- a/compiler/dd-mir/src/lowering/shape_impls.rs
+++ b/compiler/dd-mir/src/lowering/shape_impls.rs
@@ -50,7 +50,7 @@ impl Shape for Manifest {
     fn supported_properties() -> &'static [PropertyInfo<Self>] {
         static MAP: &[PropertyInfo<Manifest>] = &[
             PropertyInfo {
-                name: PropertyName::Exact("byte-order"),
+                name: PropertyName::Exact("default-byte-order"),
                 description: "Sets the global default byte order used by fieldsets. This can be overridden per device and fieldset.",
                 allowed_expression_types: Cow::Borrowed(&[Expression::ByteOrder(ByteOrder::LE)]),
                 multiple_allowed: false,
@@ -252,7 +252,7 @@ impl Shape for Device {
     fn supported_properties() -> &'static [PropertyInfo<Self>] {
         static MAP: &[PropertyInfo<Device>] = &[
             PropertyInfo {
-                name: PropertyName::Exact("byte-order"),
+                name: PropertyName::Exact("default-byte-order"),
                 description: "Sets the default byte order used by fieldsets in this device. This can be overridden per fieldset.",
                 allowed_expression_types: Cow::Borrowed(&[Expression::ByteOrder(ByteOrder::LE)]),
                 multiple_allowed: false,

--- a/device-driver/tests/basic-block.rs
+++ b/device-driver/tests/basic-block.rs
@@ -48,7 +48,7 @@ impl RegisterInterface for DeviceInterface {
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             register-address-type: u8,
             default-access: RW,
 

--- a/device-driver/tests/basic-buffer.rs
+++ b/device-driver/tests/basic-buffer.rs
@@ -33,7 +33,7 @@ impl BufferInterface for DeviceInterface {
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             buffer-address-type: u8,
 
             /// A read only buffer

--- a/device-driver/tests/basic-command.rs
+++ b/device-driver/tests/basic-command.rs
@@ -30,7 +30,7 @@ impl CommandInterface for DeviceInterface {
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             command-address-type: u8,
             default-access: RW,
             

--- a/device-driver/tests/basic-register.ddsl
+++ b/device-driver/tests/basic-register.ddsl
@@ -1,5 +1,5 @@
 device MyTestDevice {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u8,
     default-access: RW,
 

--- a/device-driver/tests/basic-register.rs
+++ b/device-driver/tests/basic-register.rs
@@ -52,7 +52,7 @@ device_driver::compile!(
     options: "--rust-defmt-feature=defmt",
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             register-address-type: u8,
             default-access: RW,
 

--- a/device-driver/tests/bit-ops.rs
+++ b/device-driver/tests/bit-ops.rs
@@ -3,7 +3,7 @@ use device_driver::{FieldsetMetadata, RegisterInterface, RegisterInterfaceBase};
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             register-address-type: u8,
             default-access: RW,
 

--- a/device-driver/tests/bulk-register.rs
+++ b/device-driver/tests/bulk-register.rs
@@ -48,7 +48,7 @@ impl RegisterInterface for DeviceInterface {
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             register-address-type: u8,
             register-address-mode: mapped,
             default-access: RW,

--- a/device-driver/tests/type-conversions.rs
+++ b/device-driver/tests/type-conversions.rs
@@ -48,7 +48,7 @@ impl RegisterInterface for DeviceInterface {
 device_driver::compile!(
     unstable_ddsl: "
         device MyTestDevice {
-            byte-order: LE,
+            default-byte-order: LE,
             register-address-type: u8,
             default-access: RW,
 

--- a/tests/ui/cases/address_types/input.ddsl
+++ b/tests/ui/cases/address_types/input.ddsl
@@ -1,5 +1,5 @@
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u16,
     command-address-type: i32,
     buffer-address-type: i8,

--- a/tests/ui/cases/basic_command/input.ddsl
+++ b/tests/ui/cases/basic_command/input.ddsl
@@ -1,5 +1,5 @@
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     command-address-type: u8,
     default-access: RW,
 

--- a/tests/ui/cases/basic_register/input.ddsl
+++ b/tests/ui/cases/basic_register/input.ddsl
@@ -1,6 +1,6 @@
 /// This is the testing device
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u8,
     default-access: RW,
 

--- a/tests/ui/cases/compile_time_explosion/input.ddsl
+++ b/tests/ui/cases/compile_time_explosion/input.ddsl
@@ -1,5 +1,5 @@
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u32,
     default-access: RW,
 

--- a/tests/ui/cases/description_string_escapes/input.ddsl
+++ b/tests/ui/cases/description_string_escapes/input.ddsl
@@ -1,5 +1,5 @@
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u8,
     default-access: RW,
 

--- a/tests/ui/cases/fieldset_access/input.ddsl
+++ b/tests/ui/cases/fieldset_access/input.ddsl
@@ -1,5 +1,5 @@
 device Device {
-    byte-order: LE,
+    default-byte-order: LE,
     register-address-type: u8,
     default-access: RW,
     

--- a/website/pages/home/index.html
+++ b/website/pages/home/index.html
@@ -73,17 +73,19 @@
 
     register operator_settings1 {
         address: 0x40,
+        access: WO,
+
         fields: fieldset _ {
             size-bytes: 1,
             /// Causes output levels to decrease as the frequency rises
-            field level_key_scaling 7:6 -> _ as enum ScalingLevel {
+            field level_key_scaling 7:6 RW -> _ as enum ScalingLevel {
                 NoChange: 0b00,
                 DB3PerOctave: 0b01,
                 DB1_5PerOctave: 0b10,
                 DB6PerOctave: 0b11,
             },
             /// Attenuates the operator output level
-            field output_level 5:0,
+            field output_level 5:0 RW,
         },
     },
 }

--- a/website/pages/playground/index.ts
+++ b/website/pages/playground/index.ts
@@ -10,7 +10,8 @@ enum Theme {
 
 const DEFAULT_CODE = `device Tmp102 {
     register-address-type: u8,
-    byte-order: BE,
+    default-byte-order: BE,
+    default-access: RW,
 
     /// The temperature value
     fieldset TempValue {


### PR DESCRIPTION
Rename byte-order to default-byte-order on manifests and devices. Fixes #282
Fix example code to use default-access. Fixes #283
Updates converter with new access rules. Fixes #281
Fix MissingRequiredProperty to use multiple patch element instead of one element with multiple patches.