### PR TITLE
feat(compiler): add optional address-offset property to device (#291)

### DIFF
--- a/book/src/gen-docs/mir-shapes/device.md
+++ b/book/src/gen-docs/mir-shapes/device.md
@@ -10,6 +10,7 @@ device Example {
     word-boundaries: "bD:0B:_",
     register-address-mode: mapped,
     default-access: RW,
+    address-offset: 0,
 
     block node,
     register node,
@@ -114,6 +115,17 @@ When set, all subobjects use this value as their access value (unless overridden
 ```ddsl
 // access specifier
 default-access: RW
+```
+#### Info
+- required: `no`
+- multiple allowed: `no`
+- supports doc comments: `no`
+### address-offset
+Defines the global address offset of this device. All objects in the device are relative to this offset.
+If this is not specified, the address offset defaults to 0.
+```ddsl
+// number
+address-offset: 0
 ```
 #### Info
 - required: `no`

--- a/compiler/dd-codegen/templates/rust/block.rs.j2
+++ b/compiler/dd-codegen/templates/rust/block.rs.j2
@@ -24,7 +24,7 @@ impl{{block_generics}} {{ block.name.to_case(Case::Pascal) }}{{block_generics}} 
     {% if block.root %}
     /// Create a new instance of the device
     pub const fn new(interface: I) -> Self {
-        Self { interface, base_address: 0 }
+        Self { interface, base_address: {{ device.address_offset }} }
     }
 
     /// Drop the driver instance and reclaim the interface

--- a/compiler/dd-lir/src/lowering.rs
+++ b/compiler/dd-lir/src/lowering.rs
@@ -45,6 +45,7 @@ pub fn transform_devices(manifest: &mir::Manifest) -> Result<Vec<lir::Device>, D
 
             Ok(lir::Device {
                 internal_address_type: find_best_internal_address_type(manifest, device),
+                address_offset: device.address_offset.value,
                 blocks,
             })
         })

--- a/compiler/dd-lir/src/lowering.rs
+++ b/compiler/dd-lir/src/lowering.rs
@@ -33,7 +33,7 @@ pub fn transform_devices(manifest: &mir::Manifest) -> Result<Vec<lir::Device>, D
                     ),
                     // Cast unchecked is fine here since this is a root block and the identifier is never used as an operation
                     name: &device.name.value.clone().cast_unchecked(),
-                    address_offset: &0,
+                    address_offset: &device.address_offset.value,
                     repeat: &None,
                     objects: &device.objects,
                 },

--- a/compiler/dd-lir/src/model.rs
+++ b/compiler/dd-lir/src/model.rs
@@ -12,6 +12,7 @@ pub struct Driver {
 
 pub struct Device {
     pub internal_address_type: Integer,
+    pub address_offset: i128,
     pub blocks: Vec<Block>,
 }
 

--- a/compiler/dd-mir/src/lib.rs
+++ b/compiler/dd-mir/src/lib.rs
@@ -72,7 +72,7 @@ pub fn find_min_max_addresses<'m>(
     let mut max_obj_found = None;
 
     let mut children_left = vec![device.objects.len()];
-    let mut address_offsets = vec![0];
+    let mut address_offsets = vec![device.address_offset.value];
 
     for object in device.iter_objects() {
         while children_left.last() == Some(&0) {
@@ -139,7 +139,7 @@ pub fn find_min_max_addresses<'m>(
 
         match object {
             Object::Device(d) => {
-                address_offsets.push(0);
+                address_offsets.push(d.address_offset.value);
                 children_left.push(d.objects.len());
             }
             Object::Block(b) => {

--- a/compiler/dd-mir/src/lowering/shape_impls.rs
+++ b/compiler/dd-mir/src/lowering/shape_impls.rs
@@ -410,6 +410,28 @@ If this value is specified, then it permits bulk register reads and writes.",
                     false
                 },
             },
+            PropertyInfo {
+                name: PropertyName::Exact("address-offset"),
+                description: "\
+Defines the global address offset of this device. All objects in the device are relative to this offset.
+If this is not specified, the address offset defaults to 0.",
+                allowed_expression_types: Cow::Borrowed(&[Expression::Number(0)]),
+                multiple_allowed: false,
+                required: false,
+                supports_doc_comments: false,
+                setter: |SetterArgs {
+                             target_object: dev,
+                             property,
+                             ..
+                         }| {
+                    dev.address_offset = property
+                        .expression
+                        .as_number()
+                        .unwrap()
+                        .with_span(property.expression.span);
+                    false
+                },
+            },
         ];
         MAP
     }

--- a/compiler/dd-mir/src/model.rs
+++ b/compiler/dd-mir/src/model.rs
@@ -251,6 +251,7 @@ pub struct Device {
     pub description: String,
     pub name: Spanned<Identifier<Type>>,
     pub default_access: Option<Access>,
+    pub address_offset: Spanned<i128>,
     pub device_config: DeviceConfig,
     pub objects: Vec<Object>,
 
@@ -397,7 +398,7 @@ impl Object {
     /// Return the address if it is specified.
     pub fn address(&self) -> Option<Spanned<i128>> {
         match self {
-            Object::Device(_) => None,
+            Object::Device(device) => Some(device.address_offset),
             Object::Block(block) => Some(block.address_offset),
             Object::Register(register) => Some(register.address),
             Object::Command(command) => Some(command.address),

--- a/compiler/dd-mir/src/passes/addresses_non_overlapping.rs
+++ b/compiler/dd-mir/src/passes/addresses_non_overlapping.rs
@@ -116,7 +116,7 @@ fn find_object_addresses<'m>(
     let mut object_addresses = Vec::new();
 
     let mut children_left = vec![device.objects.len()];
-    let mut address_offsets = vec![0];
+    let mut address_offsets = vec![device.address_offset.value];
 
     for object in device.iter_objects() {
         while children_left.last() == Some(&0) {
@@ -210,7 +210,7 @@ fn find_object_addresses<'m>(
 
         match object {
             Object::Device(d) => {
-                address_offsets.push(0);
+                address_offsets.push(d.address_offset.value);
                 children_left.push(d.objects.len());
             }
             Object::Block(b) => {

--- a/device-driver/tests/basic-buffer.rs
+++ b/device-driver/tests/basic-buffer.rs
@@ -35,6 +35,7 @@ device_driver::compile!(
         device MyTestDevice {
             default-byte-order: LE,
             buffer-address-type: u8,
+            address-offset: 100,
 
             /// A read only buffer
             buffer RoBuf {
@@ -57,11 +58,11 @@ fn buffer_write_read() {
     });
 
     device.wo_buf().write(&[0, 1, 2, 3]).unwrap();
-    assert_eq!(device.interface.last_address, 1);
+    assert_eq!(device.interface.last_address, 101);
 
     let mut buffer = [0; 8];
     let len = device.ro_buf().read(&mut buffer).unwrap();
-    assert_eq!(device.interface.last_address, 0);
+    assert_eq!(device.interface.last_address, 100);
     assert_eq!(len, 4);
     assert_eq!(&buffer[..len], &[0, 1, 2, 3]);
 }


### PR DESCRIPTION
### Summary

Adds optional `address-offset` property support to `Device` declarations.

- Added `address_offset: Spanned<i128>` to `dd_mir::model::Device`
- Implemented `address-offset` property in `Shape for Device`
- Passed `device.address_offset.value` to the root block during `dd-lir` lowering
- Updated address bounds calculation and non-overlapping passes to include device address offsets

Closes #291
