### PR TITLE
Move ti_bus_expander to v2

### DIFF
--- a/book/src/preface.md
+++ b/book/src/preface.md
@@ -67,6 +67,7 @@ V2:
 
 - [YM3812 OPL2](https://github.com/diondokter/ym3812)
 - [S2-LP radio](https://github.com/diondokter/s2lp)
+- [TI ADC Bus Expanders](https://github.com/activexray/ti-adc-expander)
 
 V1:
 
@@ -80,6 +81,5 @@ V1:
 - [ON Semiconductor CAT25040 4kbit SPI EEPROM](https://github.com/cesardtamayo/cat25040)
 - [TI BQ27441 Battery Fuel Gauge IC](https://github.com/leftger/bq27441)
 - [TI BQ25887 2-Cell Battery Charger IC](https://github.com/leftger/bq25887)
-- [TI ADC Bus Expanders](https://github.com/activexray/ti-adc-expander)
 
 Feel free to add to this list!


### PR DESCRIPTION
I have updated my library to V2 following the migration guide. Excellent work on this!